### PR TITLE
Script to switch submodules to tracking-branch

### DIFF
--- a/scripts/switch-submodule-branch.sh
+++ b/scripts/switch-submodule-branch.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Switches all submodules to the branch configured in .gitmodules.
+# The script should be called without arguments.
+
+self_script=$(readlink -f "$0")
+
+if [ "$#" -eq 0 ]; then
+  toplevel="$(git rev-parse --show-toplevel)"
+
+  # This script calls itself for each submodule with two arguments,
+  # the submodule name and toplevel directory.  The invocation of the
+  # script for each submodule will perform the switch for that submodule.
+  #
+  # The toplevel directory is needed because the script is called from
+  # the submodule directory, but the .gitmodules file is in the toplevel.
+  git submodule foreach -q --recursive "\"$self_script\" \$name $toplevel"
+else
+  name="$1"
+  toplevel="$2"
+
+  branch="$(git config -f "$toplevel/.gitmodules" submodule.$name.branch)"
+
+  if [ "$branch" = "" ]; then
+    echo -e "\e[33mWARNING: No branch is configured for submodule $name\e[0m"
+  else
+    echo -e "\e[32mSwitching submodule $name to use branch $branch\e[0m"
+    git switch -q $branch
+  fi
+fi


### PR DESCRIPTION
`git submodules` behaves in a way that if you use `git submodule update --init --recursive` or `git clone <respository_url> --recurse-submodule`, you will likely get your submodule checked out on a particular commit rather than a branch.  This can be inconvenient because committing changes in this state will leave the submodule checked out on new commits that can easily get lost if care isn't taken.

This PR adds a script that lets you switch to the tracking branch in every submodule.

Example:

```bash
$ git clone git@github.com:input-output-hk/fusion-flamingo.git fusion-flamingo-2
$ cd fusion-flamingo-2
$ git submodule update --init --recursive
$ git checkout newhoggy/test-submodules
$ cat .gitmodules
[submodule "cardano-api"]
	path = cardano-api
	url = git@github.com:input-output-hk/cardano-api.git
	branch = newhoggy/use-tag-script-from-cardano-dev-instead
[submodule "cardano-cli"]
	path = cardano-cli
	url = git@github.com:input-output-hk/cardano-cli.git
	branch = main
```

But the submodules are on specific commits:

```bash
$ (cd cardano-api; git status)
HEAD detached at 6f3ce029e
nothing to commit, working tree clean
$ (cd cardano-cli; git status)
HEAD detached at 8399c472f
nothing to commit, working tree clean
```

Running the script puts the submodules on the branches instead:

```bash
$ ../cardano-dev/scripts/switch-submodule-branch.sh
Switching submodule cardano-api to use branch newhoggy/use-tag-script-from-cardano-dev-instead
Switching submodule cardano-cli to use branch main
$ (cd cardano-api; git status)
On branch newhoggy/use-tag-script-from-cardano-dev-instead
Your branch is up to date with 'origin/newhoggy/use-tag-script-from-cardano-dev-instead'.

nothing to commit, working tree clean
$ (cd cardano-cli; git status)
On branch main
Your branch is up to date with 'origin/main'.

nothing to commit, working tree clean
```

## References

* https://stackoverflow.com/questions/1777854/how-can-i-specify-a-branch-tag-when-adding-a-git-submodule/18799234#18799234
* https://github.com/input-output-hk/cardano-node-wiki/pull/10