### PR TITLE
Configurable type in yaml changelogs

### DIFF
--- a/scripts/generate-pr-changelogs.sh
+++ b/scripts/generate-pr-changelogs.sh
@@ -1,19 +1,30 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 repository="$1"
 commit_range="$2"
 
+required_cfg_version=2
+
+git_root="$(git rev-parse --show-toplevel)"
+cfg_file="$git_root/.cardano-dev.yaml"
 root_dir="$HOME/.cache/cardano-updates"
 work_dir="$root_dir/$repository"
 download_file="$work_dir/download.yaml"
 
+cfg_version="$(cat "$cfg_file" | yq -o json | jq -r '.version')"
+notable_compatibilities_json="$(cat "$cfg_file" | yq -o json | jq -r '.changelog.options.compatibility | to_entries | map(select(.value == "add") | .key) | @json')"
+notable_types_json="$(cat "$cfg_file" | yq -o json | jq -r '.changelog.options.type | to_entries | map(select(.value == "add") | .key) | @json')"
+
+if [ "$cfg_version" -lt "$required_cfg_version" ]; then
+  echo "Unsupported config version: $cfg_version. Required config version at least: $required_cfg_version" >&2
+  exit 1
+fi
+
 trim() {
-    local trimmed=$1
-    # Remove leading whitespace
-    trimmed=${trimmed##+([[:space:]])}
-    # Remove trailing whitespace
-    trimmed=${trimmed%%+([[:space:]])}
-    printf '%s' "$trimmed"
+  local trimmed=$1
+  awk '{$1=$1}1' <<< "$trimmed"
 }
 
 extract_changelog() {
@@ -39,16 +50,21 @@ extract_changelog() {
 
 select_notable() {
   yq -o json \
-    | jq -r '
-          ["feature", "bugfix"] as $notable
+    | jq -r "
+          $notable_types_json as \$notable_types
+        | $notable_compatibilities_json as \$notable_compatibilities
         | if length == 0 then
             true
-          elif .[0] | [.type] | flatten | any([.] | inside($notable)) then
-            true
+          elif .[0] | [.type] | flatten | any([.] | inside(\$notable_types)) then
+            if .[0] | [.compatibility] | flatten | any([.] | inside(\$notable_compatibilities)) then
+              true
+            else
+              halt_error(1)
+            end
           else
             halt_error(1)
           end
-      ' \
+      " \
     > /dev/null 2> /dev/null
 }
 

--- a/scripts/tag.sh
+++ b/scripts/tag.sh
@@ -17,9 +17,10 @@
 set -euo pipefail
 
 git_root="$(git rev-parse --show-toplevel)"
-main_branch="$(cat "$git_root/.cardano-dev.yaml" | yq -o json | jq -r '."main-branch"')"
-release_branch_prefix="$(cat "$git_root/.cardano-dev.yaml" | yq -o json | jq -r '."release-branch".prefix')"
-release_branch_suffix="$(cat "$git_root/.cardano-dev.yaml" | yq -o json | jq -r '."release-branch".suffix')"
+cfg_file="$git_root/.cardano-dev.yaml" 
+main_branch="$(cat "$cfg_file" | yq -o json | jq -r '."main-branch"')"
+release_branch_prefix="$(cat "$cfg_file" | yq -o json | jq -r '."release-branch".prefix')"
+release_branch_suffix="$(cat "$cfg_file" | yq -o json | jq -r '."release-branch".suffix')"
 
 if [[ -n "$(git status --porcelain --untracked-files=no)" ]]; then
   echo -e "\e[31mRefusing to run because there are untracked changes in the repository.\e[0m"


### PR DESCRIPTION
This PR adds support for configurable changelog `type` and `compatibility`.

Sample configuration
```yaml
version: 2
main-branch: main
release-branch:
  prefix: release/
  suffix: .x
changelog:
  # Determine which PR changelog options are available and which end up in the changelog
  options:
    type:
      feature: add # that's for backwards compatibility with prevous PRs, remove this option after a release
      breaking: add
      compatible: add
      optimisation: add
      improvement: add
      bugfix: add
      test: skip
      maintenance: skip
      documentation: skip
```

Requires following PRs to be merged:
* [ ] https://github.com/input-output-hk/cardano-api/pull/166
* [ ] https://github.com/input-output-hk/cardano-cli/pull/102