### PR TITLE
Fix locating of changelog in the PR description

### DIFF
--- a/scripts/generate-pr-changelogs.sh
+++ b/scripts/generate-pr-changelogs.sh
@@ -73,7 +73,7 @@ for pr_number in $(
       .[] | select(.number == $pr_number) | .body
 JQ
     )" \
-      | awk '/# Changelog/{flag=1;next}/^#/{flag=0}flag' \
+      | awk '/# Changelog/ {found=1} found {print}' \
       | awk '/^```yaml/{flag=1;next}/^```/{flag=0}flag' \
       > "$temp_changelog_yaml"
 


### PR DESCRIPTION
After changing of PR template, changelog finding was not selecting the correct part of PR description.