### PR TITLE
generate-pr-changelogs.sh: filter away merge commits (if any)

### DIFF
--- a/scripts/generate-pr-changelogs.sh
+++ b/scripts/generate-pr-changelogs.sh
@@ -66,6 +66,7 @@ temp_changelog_yaml="$(mktemp)"
 
 for pr_number in $(
       git log --merges --oneline "$commit_range" \
+    | grep 'Merge pull request' \
     | sed 's|^[0-9a-z]\+ Merge pull request #\([0-9]\+\) .*$|\1|g'
     ); do
   cat "$download_file" | yq -o json | jq -r "$(


### PR DESCRIPTION
## Context

Bug witnessed when building https://github.com/IntersectMBO/cardano-cli/pull/542

## How to trust this PR

Run the following on `cardano-cli`:

```shell
../cardano-dev/scripts/generate-pr-changelogs.sh IntersectMBO/cardano-cli e62ea2f94a7e1bc3211f9a538093d20718a3c76b..HEAD
```

* Witness it fails before this PR
* Witness it works on this PR's tip