### PR TITLE
generate-pr-changelogs: tell user to install unavailable tools

### DIFF
--- a/scripts/generate-pr-changelogs.sh
+++ b/scripts/generate-pr-changelogs.sh
@@ -72,7 +72,7 @@ select_notable() {
 temp_changelog_yaml="$(mktemp)"
 
 for pr_number in $(
-      git log --merges --oneline "$commit_range" \
+      git log --merges --oneline --ancestry-path "$commit_range" \
     | grep 'Merge pull request' \
     | sed 's|^[0-9a-z]\+ Merge pull request #\([0-9]\+\) .*$|\1|g'
     ); do

--- a/scripts/generate-pr-changelogs.sh
+++ b/scripts/generate-pr-changelogs.sh
@@ -13,6 +13,11 @@ root_dir="$HOME/.cache/cardano-updates"
 work_dir="$root_dir/$repository"
 download_file="$work_dir/download.yaml"
 
+for tool in jq yq
+do
+  command -v $tool > /dev/null || { echo "Exiting: you need to install $tool to use this script"; exit 1; }
+done
+
 [[ -e "$download_file" ]] || { echo "$download_file doesn't exist. Did you forget to run download-prs.sh?"; exit 1; }
 
 cfg_version="$(cat "$cfg_file" | yq -o json | jq -r '.version')"


### PR DESCRIPTION
# What this PR does

Fix that commits not on the path between `HEAD` and the released commit could be included in the changelog. See https://github.com/IntersectMBO/cardano-api/pull/518#discussion_r1562299764 for more details.

# How to trust this PR

* See [this SO answer](https://stackoverflow.com/questions/18679870/list-commits-between-2-commit-hashes-in-git) for explanations about --ancestry-path.
* See [git's documentation](https://git-scm.com/docs/git-log#Documentation/git-log.txt---ancestry-pathltcommitgt) for detailed explanations about --ancestry-path (beware: wall of text :sweat_smile:)