### PR TITLE
generate-pr-changelog.sh: Hint at missing run-download-prs.sh call

### DIFF
--- a/scripts/generate-pr-changelogs.sh
+++ b/scripts/generate-pr-changelogs.sh
@@ -99,7 +99,7 @@ JQ
 JQ
           )"
     else
-      echo "- <missing changelog for PR ${pr_number}>"
+      echo "- <missing changelog for PR ${pr_number}. Did you forget to run download-prs.sh?>"
     fi
 
     cat "$download_file" | yq -o json | jq -r "$(


### PR DESCRIPTION
If you forgot to call `download-prs.sh` you can get `missing changelog for PR ..` messages.

In this case, hint that probably the call to `download-prs.sh` should be done.