### PR TITLE
generate-changelog.sh: don't use --ancestry-path for generating changelogs

### DIFF
--- a/scripts/generate-pr-changelogs.sh
+++ b/scripts/generate-pr-changelogs.sh
@@ -72,7 +72,7 @@ select_notable() {
 temp_changelog_yaml="$(mktemp)"
 
 for pr_number in $(
-      git log --merges --oneline --ancestry-path "$commit_range" \
+      git log --merges --oneline "$commit_range" \
     | grep 'Merge pull request' \
     | sed 's|^[0-9a-z]\+ Merge pull request #\([0-9]\+\) .*$|\1|g'
     ); do


### PR DESCRIPTION
`generate-changelog.sh` was skipping changelog entries which were merged before the merge commit of the previous release branch. This was because `--ancestry-path` argument of `git log` was limiting the commits to only parents or children of the first commit.

This reverts part of: https://github.com/input-output-hk/cardano-dev/pull/12 which was attempting to fix https://github.com/IntersectMBO/cardano-api/pull/518#discussion_r1562299764 . 

That discussion is about merge commits appearing twice, which is actually hard to track and work around.