### PR TITLE
Classify PRs using `.projects` field

### DIFF
--- a/scripts/generate-pr-changelogs.sh
+++ b/scripts/generate-pr-changelogs.sh
@@ -71,6 +71,8 @@ select_notable() {
 
 temp_changelog_yaml="$(mktemp)"
 
+declare -A list_of_projects=()
+
 for pr_number in $(
       git log --merges --oneline --ancestry-path "$commit_range" \
     | grep 'Merge pull request' \
@@ -84,30 +86,54 @@ JQ
       | awk '/# Changelog/ {found=1} found {print}' \
       | awk '/^```yaml/{flag=1;next}/^```/{flag=0}flag' \
       > "$temp_changelog_yaml"
+  pr_projects="$(cat "$temp_changelog_yaml" | yq -o json | jq -r ".[] | .projects? | .[]?")";
+  for project in $pr_projects;
+  do
+    list_of_projects[$project]="${list_of_projects[$project]:+${list_of_projects[$project]} }$pr_number"
+  done
+  if [ -z "$pr_projects" ]; then
+    list_of_projects["Project not specified"]="${list_of_projects["Project not specified"]:+${list_of_projects["Project not specified"]} }$pr_number"
+  fi
+done
 
-  if cat "$temp_changelog_yaml" | select_notable; then
-    if [ -s "$temp_changelog_yaml" ]; then
-      cat "$temp_changelog_yaml" \
-          | yq -o json \
-          | jq -r "$(
-              cat <<-JQ
-                  .[]
-                | ([.type] | flatten | join(", ")) as \$type_string
-                | ([.compatibility] | flatten | join(", ")) as \$compatibility
-                | ([\$type_string, \$compatibility] | map(select(. != null and . != "")) | join ("; ")) as \$type_comp
-                | "- \(.description | gsub("^[[:space:]]+|[[:space:]]+$"; "") | gsub("\n"; "\n  "))\n  (\(\$type_comp))"
-JQ
-          )"
-    else
-      echo "- <missing changelog for PR ${pr_number}. Did you forget to run download-prs.sh?>"
-    fi
-
+for project in "${!list_of_projects[@]}"; do
+  echo ""
+  echo "## $project"
+  echo ""
+  for pr_number in ${list_of_projects[$project]}; do
     cat "$download_file" | yq -o json | jq -r "$(
       cat <<-JQ
-        .[] | select(.number == $pr_number) | "  [PR \(.number)](\(.url))"
+        .[] | select(.number == $pr_number) | .body
 JQ
-    )"
+      )" \
+        | awk '/# Changelog/ {found=1} found {print}' \
+        | awk '/^```yaml/{flag=1;next}/^```/{flag=0}flag' \
+        > "$temp_changelog_yaml"
 
-    echo
-  fi
+    if cat "$temp_changelog_yaml" | select_notable; then
+      if [ -s "$temp_changelog_yaml" ]; then
+        cat "$temp_changelog_yaml" \
+            | yq -o json \
+            | jq -r "$(
+                cat <<-JQ
+                    .[]
+                  | ([.type] | flatten | join(", ")) as \$type_string
+                  | ([.compatibility] | flatten | join(", ")) as \$compatibility
+                  | ([\$type_string, \$compatibility] | map(select(. != null and . != "")) | join ("; ")) as \$type_comp
+                  | "- \(.description | gsub("^[[:space:]]+|[[:space:]]+$"; "") | gsub("\n"; "\n  "))\n  (\(\$type_comp))"
+JQ
+            )"
+      else
+        echo "- <missing changelog for PR ${pr_number}. Did you forget to run download-prs.sh?>"
+      fi
+
+      cat "$download_file" | yq -o json | jq -r "$(
+        cat <<-JQ
+          .[] | select(.number == $pr_number) | "  [PR \(.number)](\(.url))"
+JQ
+      )"
+
+      echo
+    fi
+  done
 done


### PR DESCRIPTION
Currently the [cardano-api repo](https://github.com/IntersectMBO/cardano-api) has 4 projects in it, and the `generate-pr-changelogs.sh` script collects them mixed, this makes it hard to create independent changelogs for each of the projects.

This PR takes advantage of the `projects` field if available, and it classifies the change log entries in separate lists for each of the projects in the entries listed.

- If a project doesn't have a project specified it will be classified under `Project not specified`
- If a project has several projects specified it will be classified under each of them

See this related PR: https://github.com/IntersectMBO/cardano-api/pull/950

I recommend looking at this PR by disabling whitespace changes.