### PR TITLE
Add herald: a release aid tool

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,32 @@
+# GitHub Copilot Custom Instructions
+
+## Qualified Import Aliases
+
+Multiple Haskell modules may share the same qualified alias:
+
+```haskell
+import Cardano.Api.Experimental qualified as Exp
+import Cardano.Api.Experimental.Tx qualified as Exp
+```
+
+This is valid GHC Haskell — both modules are accessible via the `Exp.` prefix. Name resolution happens at the use site; ambiguity only arises if both modules export the same identifier and it is used without disambiguation. Do **not** flag this pattern as a compile error or suggest renaming an alias unless there is an actual ambiguity at a specific use site.
+
+## Cabal File Formatting
+
+In `.cabal` files, all top-level package metadata fields (`name:`, `version:`, `synopsis:`, `description:`, `copyright:`, `author:`, `maintainer:`, `license:`, `build-type:`, etc.) are written at column 0 with no leading indentation. This is the standard Cabal format. Do **not** flag these fields as having inconsistent indentation.
+
+When reviewing diffs of `.cabal` files, do **not** confuse diff context annotations (e.g., line numbers or `|` separators) with actual file content. Only comment on the content of the file itself, not on artefacts of the diff format.
+
+## `cabal.project` sha256 Comments
+
+`source-repository-package` stanzas in `cabal.project` may contain `--sha256:` comment lines:
+
+```cabal
+source-repository-package
+  type: git
+  location: https://github.com/some/package
+  tag: abc123...
+  --sha256: sha256-AAAA...=
+```
+
+These lines are **comments** (ignored by cabal) but are consumed by Nix tooling to fetch the package source. The hash is computed using a different fetch method than the `sha256` in `flake.nix` (which uses `fetchgit`), so the two values will **intentionally differ**. Do **not** flag a mismatch between a `--sha256:` comment in `cabal.project` and the corresponding `sha256` in `flake.nix` as an error.

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+**/dist-newstyle/**
 result
+result-*

--- a/flake.lock
+++ b/flake.lock
@@ -16,20 +16,20 @@
         "type": "github"
       }
     },
-    "cabal-32": {
+    "blst": {
       "flake": false,
       "locked": {
-        "lastModified": 1603716527,
-        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
-        "owner": "haskell",
-        "repo": "cabal",
-        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
+        "lastModified": 1739372843,
+        "narHash": "sha256-IlbNMLBjs/dvGogcdbWQIL+3qwy7EXJbIDpo4xBd4bY=",
+        "owner": "supranational",
+        "repo": "blst",
+        "rev": "8c7db7fe8d2ce6e76dc398ebd4d475c0ec564355",
         "type": "github"
       },
       "original": {
-        "owner": "haskell",
-        "ref": "3.2",
-        "repo": "cabal",
+        "owner": "supranational",
+        "ref": "v0.3.14",
+        "repo": "blst",
         "type": "github"
       }
     },
@@ -100,31 +100,47 @@
         "type": "github"
       }
     },
-    "ghc-8.6.5-iohk": {
+    "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1600920045,
-        "narHash": "sha256-DO6kxJz248djebZLpSzTGD6s8WRpNI9BTwUeOf5RwY8=",
+        "lastModified": 1774572790,
+        "narHash": "sha256-6gyxlz2BV/BEqU9a/Jx6Htaw2xE69iqThIIounxBG3M=",
         "owner": "input-output-hk",
-        "repo": "ghc",
-        "rev": "95713a6ecce4551240da7c96b6176f980af75cae",
+        "repo": "hackage.nix",
+        "rev": "652204dfd06fd2a13135195baad57dfcf7046290",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
-        "ref": "release/8.6.5-iohk",
-        "repo": "ghc",
+        "repo": "hackage.nix",
         "type": "github"
       }
     },
-    "hackage": {
+    "hackage-for-stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1725842292,
-        "narHash": "sha256-8Mm7hExvNpe4gLhzAZd6SOQCz5OCVkaaiM0nNuw47iU=",
+        "lastModified": 1774571863,
+        "narHash": "sha256-iOZRO9gZIRiJ7kdLjZyGVY0ms+xUZvWKMg1gDsx4XY0=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "5a3e431c4e0ce3fff86b71c319d027fcf62961df",
+        "rev": "712954158ec8c10c6a8b09cb9de675684df1ebd2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "for-stackage",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackage-internal": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1750307553,
+        "narHash": "sha256-iiafNoeLHwlSLQTyvy8nPe2t6g5AV4PPcpMeH/2/DLs=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "f7867baa8817fab296528f4a4ec39d1c7c4da4f3",
         "type": "github"
       },
       "original": {
@@ -136,15 +152,19 @@
     "haskellNix": {
       "inputs": {
         "HTTP": "HTTP",
-        "cabal-32": "cabal-32",
         "cabal-34": "cabal-34",
         "cabal-36": "cabal-36",
         "cardano-shell": "cardano-shell",
         "flake-compat": "flake-compat",
-        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
         "hackage": "hackage",
+        "hackage-for-stackage": "hackage-for-stackage",
+        "hackage-internal": "hackage-internal",
+        "hls": "hls",
         "hls-1.10": "hls-1.10",
         "hls-2.0": "hls-2.0",
+        "hls-2.10": "hls-2.10",
+        "hls-2.11": "hls-2.11",
+        "hls-2.12": "hls-2.12",
         "hls-2.2": "hls-2.2",
         "hls-2.3": "hls-2.3",
         "hls-2.4": "hls-2.4",
@@ -154,35 +174,49 @@
         "hls-2.8": "hls-2.8",
         "hls-2.9": "hls-2.9",
         "hpc-coveralls": "hpc-coveralls",
-        "hydra": "hydra",
         "iserv-proxy": "iserv-proxy",
         "nixpkgs": [
           "haskellNix",
           "nixpkgs-unstable"
         ],
-        "nixpkgs-2003": "nixpkgs-2003",
-        "nixpkgs-2105": "nixpkgs-2105",
-        "nixpkgs-2111": "nixpkgs-2111",
-        "nixpkgs-2205": "nixpkgs-2205",
-        "nixpkgs-2211": "nixpkgs-2211",
         "nixpkgs-2305": "nixpkgs-2305",
         "nixpkgs-2311": "nixpkgs-2311",
         "nixpkgs-2405": "nixpkgs-2405",
+        "nixpkgs-2411": "nixpkgs-2411",
+        "nixpkgs-2505": "nixpkgs-2505",
+        "nixpkgs-2511": "nixpkgs-2511",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "old-ghc-nix": "old-ghc-nix",
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1725843043,
-        "narHash": "sha256-CqHTNzwDsQWt9i4KbtwDz1oUqJYoeBwfYDzDYpecmgQ=",
-        "owner": "input-output-hk",
+        "lastModified": 1774631528,
+        "narHash": "sha256-tYufdrpGh76VBfCBuFzo4TMgJPPAkjOfeM94dJGyC+A=",
+        "owner": "carbolymer",
         "repo": "haskell.nix",
-        "rev": "13ac77063159e5b4608f31aa286a1931e225b146",
+        "rev": "395a7cf54ef9ceedc1a29e9f5055fc148e48cb6f",
         "type": "github"
       },
       "original": {
-        "owner": "input-output-hk",
+        "owner": "carbolymer",
+        "ref": "remove-deprecated-pie-hardening",
         "repo": "haskell.nix",
+        "type": "github"
+      }
+    },
+    "hls": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1741604408,
+        "narHash": "sha256-tuq3+Ip70yu89GswZ7DSINBpwRprnWnl6xDYnS4GOsc=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "682d6894c94087da5e566771f25311c47e145359",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "repo": "haskell-language-server",
         "type": "github"
       }
     },
@@ -216,6 +250,57 @@
       "original": {
         "owner": "haskell",
         "ref": "2.0.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.10": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1743069404,
+        "narHash": "sha256-q4kDFyJDDeoGqfEtrZRx4iqMVEC2MOzCToWsFY+TOzY=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "2318c61db3a01e03700bd4b05665662929b7fe8b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.10.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.11": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1747306193,
+        "narHash": "sha256-/MmtpF8+FyQlwfKHqHK05BdsxC9LHV70d/FiMM7pzBM=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "46ef4523ea4949f47f6d2752476239f1c6d806fe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.11.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.12": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1758709460,
+        "narHash": "sha256-xkI8MIIVEVARskfWbGAgP5sHG/lyeKnkm0LIOJ19X5w=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "7d983de4fa7ff54369f6dd31444bdb9869aec83e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.12.0.0",
         "repo": "haskell-language-server",
         "type": "github"
       }
@@ -342,16 +427,16 @@
     "hls-2.9": {
       "flake": false,
       "locked": {
-        "lastModified": 1718469202,
-        "narHash": "sha256-THXSz+iwB1yQQsr/PY151+2GvtoJnTIB2pIQ4OzfjD4=",
+        "lastModified": 1719993701,
+        "narHash": "sha256-wy348++MiMm/xwtI9M3vVpqj2qfGgnDcZIGXw8sF1sA=",
         "owner": "haskell",
         "repo": "haskell-language-server",
-        "rev": "40891bccb235ebacce020b598b083eab9dda80f1",
+        "rev": "90319a7e62ab93ab65a95f8f2bcf537e34dae76a",
         "type": "github"
       },
       "original": {
         "owner": "haskell",
-        "ref": "2.9.0.0",
+        "ref": "2.9.0.1",
         "repo": "haskell-language-server",
         "type": "github"
       }
@@ -372,37 +457,35 @@
         "type": "github"
       }
     },
-    "hydra": {
+    "iohkNix": {
       "inputs": {
-        "nix": "nix",
-        "nixpkgs": [
-          "haskellNix",
-          "hydra",
-          "nix",
-          "nixpkgs"
-        ]
+        "blst": "blst",
+        "nixpkgs": "nixpkgs",
+        "secp256k1": "secp256k1",
+        "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1671755331,
-        "narHash": "sha256-hXsgJj0Cy0ZiCiYdW2OdBz5WmFyOMKuw4zyxKpgUKm4=",
-        "owner": "NixOS",
-        "repo": "hydra",
-        "rev": "f48f00ee6d5727ae3e488cbf9ce157460853fea8",
+        "lastModified": 1774280402,
+        "narHash": "sha256-bHp3Ji7c0T0RCor9FVo6yvjSPT0bVQE5EFw5JxvqZDM=",
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "rev": "f444d972c301ddd9f23eac4325ffcc8b5766eee9",
         "type": "github"
       },
       "original": {
-        "id": "hydra",
-        "type": "indirect"
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "type": "github"
       }
     },
     "iserv-proxy": {
       "flake": false,
       "locked": {
-        "lastModified": 1717479972,
-        "narHash": "sha256-7vE3RQycHI1YT9LHJ1/fUaeln2vIpYm6Mmn8FTpYeVo=",
+        "lastModified": 1770174258,
+        "narHash": "sha256-x6QYupvHZM7rRpVO4AIC5gUWFprFQ59A95FPC7/Owjg=",
         "owner": "stable-haskell",
         "repo": "iserv-proxy",
-        "rev": "2ed34002247213fc435d0062350b91bab920626e",
+        "rev": "91ef7ffdeedfb141a4d69dcf9e550abe3e1160c6",
         "type": "github"
       },
       "original": {
@@ -412,135 +495,18 @@
         "type": "github"
       }
     },
-    "lowdown-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1633514407,
-        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
-        "owner": "kristapsdz",
-        "repo": "lowdown",
-        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "kristapsdz",
-        "repo": "lowdown",
-        "type": "github"
-      }
-    },
-    "nix": {
-      "inputs": {
-        "lowdown-src": "lowdown-src",
-        "nixpkgs": "nixpkgs",
-        "nixpkgs-regression": "nixpkgs-regression"
-      },
-      "locked": {
-        "lastModified": 1661606874,
-        "narHash": "sha256-9+rpYzI+SmxJn+EbYxjGv68Ucp22bdFUSy/4LkHkkDQ=",
-        "owner": "NixOS",
-        "repo": "nix",
-        "rev": "11e45768b34fdafdcf019ddbd337afa16127ff0f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "2.11.0",
-        "repo": "nix",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1657693803,
-        "narHash": "sha256-G++2CJ9u0E7NNTAi9n5G8TdDmGJXcIjkJ3NF8cetQB8=",
-        "owner": "NixOS",
+        "lastModified": 1751071626,
+        "narHash": "sha256-/uHE/AD2qGq4QLigWAnBHiVvpVXB04XAfrOtw8JMv+Y=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "365e1b3a859281cf11b94f87231adeabbdd878a2",
+        "rev": "a47938d89bdf8e279ad432bd6a473cf4c430f48c",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixos-22.05-small",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2003": {
-      "locked": {
-        "lastModified": 1620055814,
-        "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-20.03-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2105": {
-      "locked": {
-        "lastModified": 1659914493,
-        "narHash": "sha256-lkA5X3VNMKirvA+SUzvEhfA7XquWLci+CGi505YFAIs=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "022caabb5f2265ad4006c1fa5b1ebe69fb0c3faf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-21.05-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2111": {
-      "locked": {
-        "lastModified": 1659446231,
-        "narHash": "sha256-hekabNdTdgR/iLsgce5TGWmfIDZ86qjPhxDg/8TlzhE=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "eabc38219184cc3e04a974fe31857d8e0eac098d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-21.11-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2205": {
-      "locked": {
-        "lastModified": 1685573264,
-        "narHash": "sha256-Zffu01pONhs/pqH07cjlF10NnMDLok8ix5Uk4rhOnZQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "380be19fbd2d9079f677978361792cb25e8a3635",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-22.05-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2211": {
-      "locked": {
-        "lastModified": 1688392541,
-        "narHash": "sha256-lHrKvEkCPTUO+7tPfjIcb7Trk6k31rz18vkyqmkeJfY=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "ea4c80b39be4c09702b0cb3b42eab59e2ba4f24b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-22.11-darwin",
+        "owner": "nixos",
+        "ref": "release-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -579,11 +545,11 @@
     },
     "nixpkgs-2405": {
       "locked": {
-        "lastModified": 1720122915,
-        "narHash": "sha256-Nby8WWxj0elBu1xuRaUcRjPi/rU3xVbkAt2kj4QwX2U=",
+        "lastModified": 1735564410,
+        "narHash": "sha256-HB/FA0+1gpSs8+/boEavrGJH+Eq08/R2wWNph1sM1Dg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "835cf2d3f37989c5db6585a28de967a667a75fb1",
+        "rev": "1e7a8f391f1a490460760065fa0630b5520f9cf8",
         "type": "github"
       },
       "original": {
@@ -593,29 +559,61 @@
         "type": "github"
       }
     },
-    "nixpkgs-regression": {
+    "nixpkgs-2411": {
       "locked": {
-        "lastModified": 1643052045,
-        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "lastModified": 1751290243,
+        "narHash": "sha256-kNf+obkpJZWar7HZymXZbW+Rlk3HTEIMlpc6FCNz0Ds=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "rev": "5ab036a8d97cb9476fbe81b09076e6e91d15e1b6",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "nixpkgs-24.11-darwin",
         "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2505": {
+      "locked": {
+        "lastModified": 1764560356,
+        "narHash": "sha256-M5aFEFPppI4UhdOxwdmceJ9bDJC4T6C6CzCK1E2FZyo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6c8f0cca84510cc79e09ea99a299c9bc17d03cb6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-25.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2511": {
+      "locked": {
+        "lastModified": 1764572236,
+        "narHash": "sha256-hLp6T/vKdrBQolpbN3EhJOKTXZYxJZPzpnoZz+fEGlE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b0924ea1889b366de6bb0018a9db70b2c43a15f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-25.11-darwin",
+        "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1720181791,
-        "narHash": "sha256-i4vJL12/AdyuQuviMMd1Hk2tsGt02hDNhA0Zj1m16N8=",
+        "lastModified": 1764587062,
+        "narHash": "sha256-hdFa0TAVQAQLDF31cEW3enWmBP+b592OvHs6WVe3D8k=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4284c2b73c8bce4b46a6adf23e16d9e2ec8da4bb",
+        "rev": "c1cb7d097cb250f6e1904aacd5f2ba5ffd8a49ce",
         "type": "github"
       },
       "original": {
@@ -645,6 +643,7 @@
     "root": {
       "inputs": {
         "haskellNix": "haskellNix",
+        "iohkNix": "iohkNix",
         "nixpkgs": [
           "haskellNix",
           "nixpkgs-unstable"
@@ -653,14 +652,48 @@
         "utils": "utils"
       }
     },
+    "secp256k1": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1683999695,
+        "narHash": "sha256-9nJJVENMXjXEJZzw8DHzin1DkFkF8h9m/c6PuM7Uk4s=",
+        "owner": "bitcoin-core",
+        "repo": "secp256k1",
+        "rev": "acf5c55ae6a94e5ca847e07def40427547876101",
+        "type": "github"
+      },
+      "original": {
+        "owner": "bitcoin-core",
+        "ref": "v0.3.2",
+        "repo": "secp256k1",
+        "type": "github"
+      }
+    },
+    "sodium": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1675156279,
+        "narHash": "sha256-0uRcN5gvMwO7MCXVYnoqG/OmeBFi8qRVnDWJLnBb9+Y=",
+        "owner": "input-output-hk",
+        "repo": "libsodium",
+        "rev": "dbb48cce5429cb6585c9034f002568964f1ce567",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "libsodium",
+        "rev": "dbb48cce5429cb6585c9034f002568964f1ce567",
+        "type": "github"
+      }
+    },
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1725840910,
-        "narHash": "sha256-Sv/CQAO0kwg3g8q/Cdy8tzXNAO4dDDtjj8aNRRGRvvY=",
+        "lastModified": 1774570839,
+        "narHash": "sha256-tyAzxmjnAtwAux2Dbw5yUOTPhNcFrDjpvQlVtFqA8Ak=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "61e0766039b352477f8a885faea24f5149019fbf",
+        "rev": "af474ea91cba204905ee7d2273a0f1782b13ed46",
         "type": "github"
       },
       "original": {
@@ -691,11 +724,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,61 +2,263 @@
   description = "A list of useful scripts for cardano-node development";
   inputs = {
     systems.url = "github:nix-systems/default";
-    haskellNix.url = "github:input-output-hk/haskell.nix";
+    haskellNix.url = "github:carbolymer/haskell.nix/remove-deprecated-pie-hardening";
     nixpkgs.follows = "haskellNix/nixpkgs-unstable";
+    iohkNix.url = "github:input-output-hk/iohk-nix";
     utils.url = "github:numtide/flake-utils";
     utils.inputs.systems.follows = "systems";
   };
 
-  outputs = { nixpkgs, utils, ... }:
-    utils.lib.eachDefaultSystem (system:
+  outputs =
+    {
+      nixpkgs,
+      haskellNix,
+      iohkNix,
+      utils,
+      ...
+    }@inputs:
+    utils.lib.eachDefaultSystem (
+      system:
       let
-        pkgs = import nixpkgs { inherit system; };
+        pkgs = import nixpkgs {
+          inherit system;
+          inherit (haskellNix) config;
+          overlays = [ haskellNix.overlay ];
+        };
 
         # list of all scripts (without .sh suffix)
-        scripts = with pkgs.lib;
-          map (removeSuffix ".sh") (filter (hasSuffix ".sh")
-            (builtins.attrNames (builtins.readDir ./scripts)));
+        scripts =
+          with pkgs.lib;
+          map (removeSuffix ".sh") (
+            filter (hasSuffix ".sh") (builtins.attrNames (builtins.readDir ./scripts))
+          );
 
         # wrap a shell script, adding programs to its PATH
-        wrap = { paths ? [ ], vars ? { }, file ? null, script ? null
-          , name ? "wrap" }:
-          assert file != null || script != null
-            || abort "wrap needs 'file' or 'script' argument";
+        wrap =
+          {
+            paths ? [ ],
+            vars ? { },
+            file ? null,
+            script ? null,
+            name ? "wrap",
+          }:
+          assert file != null || script != null || abort "wrap needs 'file' or 'script' argument";
           let
-            set = with pkgs.lib;
+            set =
+              with pkgs.lib;
               n: v:
-              "--set ${escapeShellArg (escapeShellArg n)} "
-              + "'\"'${escapeShellArg (escapeShellArg v)}'\"'";
-            args = (map (p: "--prefix PATH : ${p}/bin") paths)
-              ++ (pkgs.lib.attrValues (pkgs.lib.mapAttrs set vars));
-          in pkgs.runCommand name {
-            f = if file == null then pkgs.lib.writeScript name script else file;
-            buildInputs = [ pkgs.makeWrapper ];
-          } ''
-            makeWrapper "$f" "$out" ${toString args}
-          '';
+              "--set ${escapeShellArg (escapeShellArg n)} " + "'\"'${escapeShellArg (escapeShellArg v)}'\"'";
+            args =
+              (map (p: "--prefix PATH : ${p}/bin") paths) ++ (pkgs.lib.attrValues (pkgs.lib.mapAttrs set vars));
+          in
+          pkgs.runCommand name
+            {
+              f = if file == null then pkgs.lib.writeScript name script else file;
+              buildInputs = [ pkgs.makeWrapper ];
+            }
+            ''
+              makeWrapper "$f" "$out" ${toString args}
+            '';
 
         # create an app for a script name
         mkScriptApp = scriptName: {
           type = "app";
-          program = (wrap {
-            name = scriptName;
-            paths = with pkgs; [ git gh jq yq-go ];
-            file = ./scripts/${scriptName}.sh;
-          }).outPath;
+          program =
+            (wrap {
+              name = scriptName;
+              paths = with pkgs; [
+                git
+                gh
+                jq
+                yq-go
+              ];
+              file = ./scripts/${scriptName}.sh;
+            }).outPath;
         };
-      in {
-        # create an app for every script in `scripts` directory
-        apps = pkgs.lib.foldl' (acc: s: acc // { ${s} = mkScriptApp s; }) { }
-          scripts;
-        formatter = pkgs.nixfmt-classic;
-      });
+
+        inherit (pkgs) lib;
+
+        # herald — haskell.nix project
+        heraldProject = pkgs.haskell-nix.cabalProject' {
+          src = ./herald;
+          compiler-nix-name = ghcVersion;
+          crossPlatforms =
+            p:
+            lib.optionals (system == "x86_64-linux") [
+              p.ucrt64
+              p.musl64
+              p.aarch64-multiplatform-musl
+            ]
+            ++ lib.optionals (system == "aarch64-linux") [ p.aarch64-multiplatform-musl ];
+          modules = [
+            (
+              { lib, pkgs, ... }:
+              lib.mkIf pkgs.stdenv.hostPlatform.isWindows {
+                packages.basement.configureFlags = [ "--hsc2hs-option=--cflag=-Wno-int-conversion" ];
+              }
+            )
+          ];
+        };
+
+        heraldExe = heraldProject.hsPkgs.herald.components.exes.herald;
+        heraldTestExe = heraldProject.hsPkgs.herald.components.tests.herald-test;
+        heraldE2eExe = heraldProject.hsPkgs.herald.components.tests.herald-test-e2e;
+
+        # Best available exe for the current system:
+        # Linux gets a static musl build (minimal closure), macOS gets dynamic.
+        heraldPlatformExe =
+          if system == "x86_64-linux" then
+            heraldProject.projectCross.musl64.hsPkgs.herald.components.exes.herald
+          else if system == "aarch64-linux" then
+            heraldProject.projectCross.aarch64-multiplatform-musl.hsPkgs.herald.components.exes.herald
+          else
+            heraldExe;
+
+        ghcVersion = "ghc9122";
+
+        # Pinned tool versions shared between devShell and CI lint check
+        toolVersions = {
+          cabal = "latest";
+          fourmolu = "0.18.0.0";
+          hlint = "3.10";
+          cabal-gild = "1.7.0.1";
+        };
+
+        heraldRelease =
+          lib.optionalAttrs (system == "x86_64-linux") {
+            x86_64-linux = heraldProject.projectCross.musl64.hsPkgs.herald.components.exes.herald;
+            aarch64-linux =
+              heraldProject.projectCross.aarch64-multiplatform-musl.hsPkgs.herald.components.exes.herald;
+            x86_64-windows = heraldProject.projectCross.ucrt64.hsPkgs.herald.components.exes.herald;
+          }
+          // lib.optionalAttrs (system == "aarch64-linux") {
+            aarch64-linux =
+              heraldProject.projectCross.aarch64-multiplatform-musl.hsPkgs.herald.components.exes.herald;
+          }
+          // lib.optionalAttrs (system == "x86_64-darwin" || system == "aarch64-darwin") {
+            ${system} = heraldExe;
+          };
+        checks =
+          let
+            locale =
+              if pkgs.stdenv.hostPlatform.isDarwin then "en_US.UTF-8" else "C.UTF-8";
+
+          in
+          {
+            test =
+              pkgs.runCommand "herald-test"
+                {
+                  LANG = locale;
+                  LC_ALL = locale;
+                }
+                ''
+                  ${heraldTestExe}/bin/herald-test
+                  touch $out
+                '';
+            e2e =
+              pkgs.runCommand "herald-e2e"
+                {
+                  LANG = locale;
+                  LC_ALL = locale;
+                  nativeBuildInputs = [ pkgs.git ];
+                }
+                ''
+                  export HOME=$TMPDIR
+                  git config --global user.email "test@test.com"
+                  git config --global user.name "Test"
+                  ${heraldE2eExe}/bin/herald-test-e2e
+                  touch $out
+                '';
+          lint =
+            let
+              fourmolu = pkgs.haskell-nix.tool ghcVersion "fourmolu" toolVersions.fourmolu;
+              hlint = pkgs.haskell-nix.tool ghcVersion "hlint" toolVersions.hlint;
+              cabal-gild = pkgs.haskell-nix.tool ghcVersion "cabal-gild" toolVersions.cabal-gild;
+            in
+            pkgs.runCommand "herald-lint"
+              {
+                nativeBuildInputs = [
+                  fourmolu
+                  hlint
+                  cabal-gild
+                  pkgs.diffutils
+                ];
+                src = ./herald;
+              }
+              ''
+                cd $src
+                fourmolu --mode check src/ test/ app/ test-e2e/
+                hlint src/ test/ app/ test-e2e/
+                cabal-gild --input herald.cabal > $TMPDIR/formatted.cabal
+                diff -u herald.cabal $TMPDIR/formatted.cabal
+                touch $out
+              '';
+        };
+      in
+      {
+        # create an app for every script in `scripts` directory, plus herald
+        apps = pkgs.lib.foldl' (acc: s: acc // { ${s} = mkScriptApp s; }) {
+          herald = {
+            type = "app";
+            program = "${heraldPlatformExe}/bin/herald";
+          };
+          herald-dy = {
+            type = "app";
+            program = "${heraldExe}/bin/herald";
+          };
+        } scripts;
+        packages = {
+          herald = heraldPlatformExe;
+        }
+        // heraldRelease;
+        devShells = {
+          herald = heraldProject.shellFor {
+            tools = toolVersions;
+            # Skip cross-compilation deps in the dev shell
+            crossPlatforms = _: [ ];
+            shellHook = ''
+              export LANG="en_US.UTF-8"
+            '' + lib.optionalString
+              (pkgs.glibcLocales != null && pkgs.stdenv.hostPlatform.libc == "glibc") ''
+              export LOCALE_ARCHIVE="${pkgs.glibcLocales}/lib/locale/locale-archive"
+            '';
+          };
+        };
+        inherit checks;
+        hydraJobs = pkgs.callPackages iohkNix.utils.ciJobsAggregates {
+          ciJobs = {
+            herald = {
+              inherit (heraldProject.hsPkgs.herald.components) library;
+              exe = heraldExe;
+              static = heraldPlatformExe;
+              tests = heraldTestExe;
+              e2e = heraldE2eExe;
+            }
+            // lib.optionalAttrs (heraldRelease != { }) {
+              release = heraldRelease;
+            };
+            inherit checks;
+            revision = pkgs.writeText "revision" (inputs.self.rev or "dirty");
+          }
+          // lib.optionalAttrs (system == "x86_64-linux") {
+            windows =
+              let
+                windowsProject = heraldProject.projectCross.ucrt64;
+              in
+              {
+                inherit (windowsProject.hsPkgs.herald.components) library;
+                inherit (windowsProject.hsPkgs.herald.components.exes) herald;
+                inherit (windowsProject.hsPkgs.herald.components.tests) herald-test;
+              };
+          };
+        };
+        formatter = pkgs.nixfmt;
+      }
+    );
 
   nixConfig = {
     extra-substituters = [ "https://cache.iog.io" ];
-    extra-trusted-public-keys =
-      [ "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=" ];
+    extra-trusted-public-keys = [ "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=" ];
     allow-import-from-derivation = true;
   };
 }

--- a/herald/.github/actions/release/action.yml
+++ b/herald/.github/actions/release/action.yml
@@ -1,0 +1,213 @@
+name: Herald Release
+description: >
+  Batch changelog fragments for a package, create a release commit and tag,
+  open a pull request on a release branch, and add a release changelog fragment
+  for the next cycle.
+
+inputs:
+  package:
+    description: Package name to release (must match a project in .herald.yml).
+    required: true
+  version:
+    description: >
+      Explicit version (A.B.C.D). If omitted, auto-computed from changelog
+      fragments and the current .cabal version.
+    required: false
+    default: ''
+  config:
+    description: Path to the herald config file, relative to the repository root.
+    required: false
+    default: .herald.yml
+  herald-ref:
+    description: Flake reference for the cardano-dev repository containing herald.
+    required: false
+    default: github:input-output-hk/cardano-dev
+  base-branch:
+    description: >
+      Branch to target for the release PR. If omitted, auto-detected from the
+      repository's default branch.
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Detect base branch
+      id: default-branch
+      shell: bash
+      run: |
+        DEFAULT="${{ inputs.base-branch }}"
+        if [ -z "$DEFAULT" ]; then
+          DEFAULT=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null \
+            | sed 's|refs/remotes/origin/||') || true
+        fi
+        if [ -z "$DEFAULT" ]; then
+          DEFAULT=$(git remote show origin 2>/dev/null \
+            | grep 'HEAD branch' | awk '{print $NF}') || true
+        fi
+        if [ -z "$DEFAULT" ]; then
+          echo "::error::Could not detect base branch"
+          exit 1
+        fi
+        echo "name=$DEFAULT" >> "$GITHUB_OUTPUT"
+
+    - name: Configure git
+      shell: bash
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+
+    - name: Fetch herald
+      id: herald
+      shell: bash
+      run: |
+        echo "::group::Fetching herald"
+        HERALD="$(nix build --accept-flake-config "${{ inputs.herald-ref }}#herald" --no-link --print-out-paths)/bin/herald"
+        echo "::endgroup::"
+        echo "bin=$HERALD" >> "$GITHUB_OUTPUT"
+
+    - name: Compute version
+      id: version
+      shell: bash
+      run: |
+        PACKAGE="${{ inputs.package }}"
+        HERALD="${{ steps.herald.outputs.bin }}"
+        CONFIG="-c ${{ inputs.config }}"
+
+        if [ -n "${{ inputs.version }}" ]; then
+          echo "value=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+        else
+          if ! VERSION=$($HERALD $CONFIG next "$PACKAGE"); then
+            echo "::error::herald next failed for $PACKAGE, see log above"
+            exit 1
+          fi
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not compute next version for $PACKAGE (empty output)."
+            exit 1
+          fi
+          echo "value=$VERSION" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Check tag does not exist
+      shell: bash
+      run: |
+        TAG="${{ inputs.package }}-${{ steps.version.outputs.value }}"
+        if git rev-parse "$TAG" >/dev/null 2>&1; then
+          echo "::error::Tag $TAG already exists locally"
+          exit 1
+        fi
+        if git ls-remote --tags origin "refs/tags/$TAG" | grep -q .; then
+          echo "::error::Tag $TAG already exists on remote"
+          exit 1
+        fi
+
+    - name: Create release branch
+      shell: bash
+      run: |
+        BRANCH="release/${{ inputs.package }}-${{ steps.version.outputs.value }}"
+        git checkout -b "$BRANCH"
+        echo "RELEASE_BRANCH=$BRANCH" >> "$GITHUB_ENV"
+        echo "RELEASE_TAG=${{ inputs.package }}-${{ steps.version.outputs.value }}" >> "$GITHUB_ENV"
+
+    - name: Batch changelog fragments
+      shell: bash
+      run: |
+        HERALD="${{ steps.herald.outputs.bin }}"
+        CONFIG="-c ${{ inputs.config }}"
+        VERSION_ARG=""
+        if [ -n "${{ inputs.version }}" ]; then
+          VERSION_ARG="--version ${{ inputs.version }}"
+        fi
+
+        $HERALD $CONFIG batch "${{ inputs.package }}" --commit-tag $VERSION_ARG
+
+    - name: Push release branch and tag
+      shell: bash
+      run: |
+        git push -q -u origin "$RELEASE_BRANCH"
+        git push -q origin "$RELEASE_TAG"
+
+    - name: Create pull request
+      id: pr
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        PACKAGE="${{ inputs.package }}"
+        VERSION="${{ steps.version.outputs.value }}"
+        DEFAULT_BRANCH="${{ steps.default-branch.outputs.name }}"
+
+        PR_URL=$(gh pr create \
+          --title "Release $PACKAGE $VERSION" \
+          --base "$DEFAULT_BRANCH" \
+          --head "$RELEASE_BRANCH" \
+          --body "Release in progress -- PR body will be updated shortly.")
+
+        PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
+        echo "url=$PR_URL" >> "$GITHUB_OUTPUT"
+        echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
+    - name: Add release changelog fragment
+      shell: bash
+      run: |
+        HERALD="${{ steps.herald.outputs.bin }}"
+        CONFIG="-c ${{ inputs.config }}"
+        PACKAGE="${{ inputs.package }}"
+        VERSION="${{ steps.version.outputs.value }}"
+        PR_NUMBER="${{ steps.pr.outputs.number }}"
+
+        $HERALD $CONFIG new \
+          --project "$PACKAGE" \
+          --kind release \
+          --description "Release $PACKAGE $VERSION" \
+          --pr "$PR_NUMBER"
+
+        git add .changes/
+        git commit --no-verify --no-gpg-sign \
+          -m "Add release changelog fragment for $PACKAGE $VERSION"
+        git push
+
+    - name: Update PR body
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        PACKAGE="${{ inputs.package }}"
+        VERSION="${{ steps.version.outputs.value }}"
+        DEFAULT_BRANCH="${{ steps.default-branch.outputs.name }}"
+        TAG="$RELEASE_TAG"
+        BRANCH="$RELEASE_BRANCH"
+        PR_NUMBER="${{ steps.pr.outputs.number }}"
+        COMMIT_COUNT=$(git rev-list --count "origin/${DEFAULT_BRANCH}..HEAD")
+        # The tag is on the batch commit, which is one before the release fragment
+        TAG_OFFSET=$((COMMIT_COUNT - 1))
+
+        cat > /tmp/pr-body.md <<EOF
+        ## Summary
+
+        - Batch changelog fragments for \`$PACKAGE\` into version \`$VERSION\`
+        - Update changelog file with a new release section
+        - Bump \`.cabal\` version to \`$VERSION\`
+        - Remove consumed changelog fragments
+        - Add release changelog fragment for the next cycle
+        - Tag: \`$TAG\`
+
+        ## Before merging
+
+        The commits in this PR are **unsigned**. To sign them before merging, run:
+
+        \`\`\`bash
+        git fetch origin $BRANCH
+        git checkout $BRANCH
+        git rebase HEAD~${COMMIT_COUNT} --exec 'git commit --amend --no-edit -S'
+        git tag -f $TAG HEAD~${TAG_OFFSET}
+        git push --force-with-lease origin $BRANCH
+        git push --force origin $TAG
+        \`\`\`
+
+        Generated with [herald](https://github.com/input-output-hk/cardano-dev)
+        EOF
+        sed -i 's/^        //' /tmp/pr-body.md
+        gh pr edit "$PR_NUMBER" --body-file /tmp/pr-body.md
+
+        echo "::notice::Release PR: ${{ steps.pr.outputs.url }}"

--- a/herald/.github/actions/validate/action.yml
+++ b/herald/.github/actions/validate/action.yml
@@ -1,0 +1,76 @@
+name: Herald Validate
+description: >
+  Validate changelog fragments in a pull request.
+  Checks that fragments parse correctly, that modified projects have fragments (--diff),
+  and that the PR number in each fragment matches the pull request (--pr).
+
+inputs:
+  version:
+    description: >
+      Herald flake ref. Use a git ref (tag, branch, or SHA) from the cardano-dev repository.
+    required: false
+    default: github:input-output-hk/cardano-dev
+  config:
+    description: Path to the herald config file, relative to the repository root.
+    required: false
+    default: .herald.yml
+  diff:
+    description: >
+      When 'true', check that every project with modified files has at least one
+      changelog fragment on this branch.
+    required: false
+    default: 'true'
+  pr:
+    description: >
+      When 'true', verify that the PR number in each new changelog fragment matches
+      the pull request number from the GitHub event context.
+    required: false
+    default: 'true'
+
+runs:
+  using: composite
+  steps:
+    - name: Detect PR number
+      id: pr-number
+      if: inputs.pr == 'true'
+      shell: bash
+      run: |
+        PR_NUMBER="${{ github.event.pull_request.number }}"
+        if [ -z "$PR_NUMBER" ]; then
+          echo "::warning::Could not detect PR number from event context, skipping --pr check"
+          echo "available=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "available=true" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Ensure origin/HEAD is set
+      shell: bash
+      run: |
+        if ! git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null; then
+          BASE_REF="${{ github.event.pull_request.base.ref }}"
+          if [ -n "$BASE_REF" ]; then
+            git symbolic-ref refs/remotes/origin/HEAD "refs/remotes/origin/$BASE_REF"
+          else
+            git remote set-head origin --auto
+          fi
+        fi
+
+    - name: Validate changelog fragments
+      shell: bash
+      run: |
+        ARGS="-c ${{ inputs.config }}"
+        VALIDATE_ARGS=""
+
+        if [ "${{ inputs.diff }}" = "true" ]; then
+          VALIDATE_ARGS="$VALIDATE_ARGS --diff"
+        fi
+
+        if [ "${{ inputs.pr }}" = "true" ] && [ "${{ steps.pr-number.outputs.available }}" = "true" ]; then
+          VALIDATE_ARGS="$VALIDATE_ARGS --pr ${{ steps.pr-number.outputs.number }}"
+        fi
+
+        echo "::group::Fetching herald"
+        HERALD="$(nix build --accept-flake-config "${{ inputs.version }}#herald" --no-link --print-out-paths)/bin/herald"
+        echo "::endgroup::"
+        "$HERALD" $ARGS validate $VALIDATE_ARGS

--- a/herald/.github/workflows/release.yml
+++ b/herald/.github/workflows/release.yml
@@ -1,0 +1,52 @@
+# Example workflow -- copy this into the consuming repository's .github/workflows/
+#
+# Triggered manually via the GitHub Actions UI or CLI:
+#   gh workflow run release.yml -f package=my-package
+#   gh workflow run release.yml -f package=my-package -f version=2.0.0.0
+#
+# What it does:
+#   1. Batches changelog fragments into a new changelog section
+#   2. Bumps the .cabal version (auto-computed or explicit)
+#   3. Creates a release commit and PACKAGE-VERSION tag
+#   4. Adds a release changelog fragment for the next cycle
+#   5. Pushes to a release/PACKAGE-VERSION branch
+#   6. Opens a PR with instructions for signing the commits
+
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      package:
+        description: Package name to release (must match a project in .herald.yml)
+        required: true
+        type: string
+      version:
+        description: Explicit version (A.B.C.D). Leave empty to auto-compute.
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: cachix/install-nix-action@v30
+        with:
+          extra_nix_config: |
+            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
+            substituters = https://cache.iog.io/ https://cache.nixos.org/
+
+      - uses: input-output-hk/cardano-dev/herald/.github/actions/release@main
+        with:
+          package: ${{ inputs.package }}
+          version: ${{ inputs.version }}
+          # herald-ref: github:input-output-hk/cardano-dev  # default
+          # config: .herald.yml                               # default

--- a/herald/.github/workflows/validate-changelogs.yml
+++ b/herald/.github/workflows/validate-changelogs.yml
@@ -1,0 +1,34 @@
+# Example workflow -- copy this into the consuming repository's .github/workflows/
+#
+# Validates changelog fragments on every pull request:
+#   - All fragment files parse correctly and reference valid projects/kinds
+#   - Modified projects have at least one changelog fragment (--diff)
+#   - PR numbers inside fragments match the pull request number (--pr)
+
+name: Validate Changelogs
+
+on:
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Fetch full history so herald can determine the fork point
+          # for --diff and --pr checks
+          fetch-depth: 0
+
+      - uses: cachix/install-nix-action@v30
+        with:
+          extra_nix_config: |
+            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
+            substituters = https://cache.iog.io/ https://cache.nixos.org/
+
+      - uses: input-output-hk/cardano-dev/herald/.github/actions/validate@main
+        # with:
+        #   version: github:input-output-hk/cardano-dev  # default -- flake ref
+        #   config: .herald.yml                   # default
+        #   diff: 'true'                          # default
+        #   pr: 'true'                            # default

--- a/herald/.hlint.yaml
+++ b/herald/.hlint.yaml
@@ -1,0 +1,75 @@
+# HLint configuration file
+# https://github.com/ndmitchell/hlint
+##########################
+
+# This file contains a template configuration file, which is typically
+# placed as .hlint.yaml in the root of your project
+
+
+# Specify additional command line arguments
+#
+# - arguments: [--color, --cpp-simple, -XQuasiQuotes]
+
+
+# Control which extensions/flags/modules/functions can be used
+#
+# - extensions:
+#   - default: false # all extension are banned by default
+#   - name: [PatternGuards, ViewPatterns] # only these listed extensions can be used
+#   - {name: CPP, within: CrossPlatform} # CPP can only be used in a given module
+#
+# - flags:
+#   - {name: -w, within: []} # -w is allowed nowhere
+#
+# - modules:
+#   - {name: [Data.Set, Data.HashSet], as: Set} # if you import Data.Set qualified, it must be as 'Set'
+#   - {name: Control.Arrow, within: []} # Certain modules are banned entirely
+#
+# - functions:
+#   - {name: unsafePerformIO, within: []} # unsafePerformIO can only appear in no modules
+
+
+# Add custom hints for this project
+#
+# Will suggest replacing "wibbleMany [myvar]" with "wibbleOne myvar"
+# - error: {lhs: "wibbleMany [x]", rhs: wibbleOne x}
+
+# The hints are named by the string they display in warning messages.
+# For example, if you see a warning starting like
+#
+# Main.hs:116:51: Warning: Redundant ==
+#
+# You can refer to that hint with `{name: Redundant ==}` (see below).
+
+# Turn on hints that are off by default
+#
+# Ban "module X(module X) where", to require a real export list
+# - warn: {name: Use explicit module export list}
+#
+# Replace a $ b $ c with a . b $ c
+# - group: {name: dollar, enabled: true}
+#
+# Generalise map to fmap, ++ to <>
+# - group: {name: generalise, enabled: true}
+
+
+# Ignore some builtin hints
+# - ignore: {name: Use let}
+# - ignore: {name: Use const, within: SpecialModule} # Only within certain modules
+
+# Allow snake_case naming in test modules (following Haskell test property convention)
+- ignore: {name: Use camelCase, within: [Test.Cardano.Api.**, Test.Golden.Cardano.Api.**]}
+
+# Ignore all files in cardano-rpc/gen (generated code)
+- ignore: {within: [Proto.Cardano.**, Proto.Utxorpc.**]}
+
+- ignore: {name: Eta reduce}
+- ignore: {name: Use + directly}
+- ignore: {name: Use fmap}
+
+# Define some custom infix operators
+# - fixity: infixr 3 ~^#^~
+
+
+# To generate a suitable file for HLint do:
+# $ hlint --default > .hlint.yaml

--- a/herald/README.md
+++ b/herald/README.md
@@ -1,0 +1,372 @@
+# Herald
+
+[![Hydra](https://img.shields.io/badge/ci-hydra-blue)](https://ci.iog.io/jobset/input-output-hk-cardano-dev)
+
+Changelog and release automation for PVP-versioned Haskell projects.
+
+Herald replaces manual PR-description-based changelog workflows with file-based
+changelog fragments. Each PR commits a small YAML file describing the change;
+at release time, Herald collects fragments, computes the next PVP version, updates
+the changelog and `.cabal` file, and can create a release commit with tag.
+
+## Features
+
+- **PVP versioning** -- 4-part versions (A.B.C.D) with auto-bumping based on change kinds
+- **Mono-repo support** -- multiple packages, each with its own changelog and `.cabal` file
+- **Multi-select kinds** -- each fragment can have multiple change kinds (e.g. bugfix + refactoring)
+- **Non-notable filtering** -- internal changes (test, refactoring, maintenance) bump the version but are hidden from the changelog
+- **CI validation** -- validate fragments, check PR numbers, detect missing fragments for modified projects
+- **Automated releases** -- GitHub Actions for validation and release PR creation
+
+## Installation
+
+Herald is distributed as a nix flake from the `cardano-dev` repository:
+
+```bash
+# Run directly
+nix run github:input-output-hk/cardano-dev#herald -- --help
+
+# Enter a dev shell (for development)
+nix develop github:input-output-hk/cardano-dev#herald
+```
+
+## Quick start
+
+### 1. Initialize a repository
+
+```bash
+herald init
+```
+
+This scans the repo for projects (directories with `.cabal` files), generates
+`.herald.yml` with discovered projects and default change kinds, and creates
+a `.changes/_TEMPLATE.yml` template fragment.
+
+### 2. Create a changelog fragment
+
+```bash
+# Interactive mode (prompts for project, kinds, description, PR number)
+herald new
+
+# Non-interactive mode
+herald new --project cardano-api --kind bugfix,refactoring --description "Fix certificate serialization" --pr 1234
+```
+
+Fragments are YAML files stored in the changes directory (default: `.changes/`):
+
+```yaml
+project: cardano-api
+kind:
+  - bugfix
+  - refactoring
+description: |
+  Fix serialization of Conway certificates
+pr: 1234
+```
+
+### 3. Validate fragments (CI)
+
+```bash
+# Validate all fragment files
+herald validate
+
+# Check that modified projects in the current branch have fragments (requires git history)
+herald validate --diff
+
+# Also verify PR numbers in fragments match
+herald validate --diff --pr 1234
+```
+
+### 4. Compute the next version
+
+```bash
+herald next cardano-api
+# prints e.g. 8.5.0.0
+```
+
+The version is computed from the current `.cabal` version plus the highest
+bump level across unreleased fragments for that package.
+
+### 5. Batch a release
+
+```bash
+# Auto-compute version from fragments
+herald batch cardano-api
+
+# Explicit version
+herald batch cardano-api --version 9.0.0.0
+
+# Batch and create a git commit
+herald batch cardano-api --commit
+
+# Batch, commit, and create a PACKAGE-VERSION tag
+herald batch cardano-api --commit-tag
+```
+
+Batching:
+1. Collects unreleased fragments for the package
+2. Renders a changelog section with the new version and date
+3. Prepends the section to the package's `CHANGELOG.md`
+4. Updates the `version:` field in the package's `.cabal` file
+5. Removes consumed fragment files
+
+## Configuration
+
+Herald is configured via `.herald.yml` (or a custom path with `-c`):
+
+```yaml
+# GitHub repository (used for PR links in changelogs)
+# Accepts: full HTTPS URL, SSH URL, or owner/repo slug (assumes GitHub)
+git-repo: https://github.com/IntersectMBO/cardano-api
+
+# Directory for changelog fragments
+changes-dir: .changes
+
+# Change kinds and their properties
+kinds:
+  breaking:
+    bump: 0.1.0.0
+    description: the API has changed in a breaking way
+  feature:
+    bump: 0.0.1.0
+    description: introduces a new feature
+  compatible:
+    bump: 0.0.1.0
+    description: the API has changed but is non-breaking
+  bugfix:
+    bump: 0.0.0.1
+    description: fixes a defect
+  optimisation:
+    bump: 0.0.0.1
+    description: measurable performance improvements
+  refactoring:
+    notable: false
+    bump: 0.0.0.1
+    description: code quality improvements
+  test:
+    notable: false
+    bump: 0.0.0.1
+    description: fixes or modifies tests
+  maintenance:
+    notable: false
+    bump: 0.0.0.1
+    description: not directly related to the code
+  release:
+    notable: false
+    bump: 0.0.0.1
+    description: related to a new release preparation
+  documentation:
+    notable: false
+    bump: 0.0.0.1
+    description: change in code docs, haddocks
+
+# Projects in this repository
+projects:
+  cardano-api:
+    changelog: cardano-api/CHANGELOG.md
+    cabal-file: cardano-api/cardano-api.cabal
+  cardano-api-gen:
+    changelog: cardano-api-gen/CHANGELOG.md
+    cabal-file: cardano-api-gen/cardano-api-gen.cabal
+```
+
+### Kind properties
+
+- **`bump`** -- PVP version component to bump. `0.1.0.0` bumps the 2nd digit (breaking),
+  `0.0.1.0` the 3rd (features), `0.0.0.1` the 4th (patches). The highest bump across
+  all fragment kinds determines the final version bump.
+- **`notable`** (default: `true`) -- if `false`, entries with only non-notable kinds
+  are hidden from the rendered changelog but still contribute to version bumping.
+- **`description`** (optional) -- shown in interactive prompts.
+
+## Changelog output format
+
+```markdown
+## 8.5.0.0 -- 2026-03-25
+
+- Add Conway era support
+  (breaking, feature)
+  [PR 99](https://github.com/IntersectMBO/cardano-api/pull/99)
+
+- Fix serialization of Conway certificates
+  (bugfix)
+  [PR 42](https://github.com/IntersectMBO/cardano-api/pull/42)
+```
+
+Entries are sorted by PR number (descending). Each entry shows the description,
+kinds in parentheses, and a link to the PR.
+
+## GitHub Actions
+
+Herald provides two reusable GitHub Actions for CI and release automation.
+Both use nix to run Herald, so no Haskell toolchain setup is needed.
+
+### Validate changelogs on PRs
+
+Copy `.github/workflows/validate-changelogs.yml` to your repository, or
+reference the composite action directly:
+
+```yaml
+name: Validate Changelogs
+
+on:
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: cachix/install-nix-action@v30
+        with:
+          extra_nix_config: |
+            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
+            substituters = https://cache.iog.io/ https://cache.nixos.org/
+
+      - uses: input-output-hk/cardano-dev/herald/.github/actions/validate@main
+        # with:
+        #   config: .herald.yml     # default
+        #   diff: 'true'            # default -- check modified projects have fragments
+        #   pr: 'true'              # default -- check PR numbers match
+```
+
+The validate action:
+- Validates all fragment files parse correctly and reference valid projects/kinds
+- Checks that projects with modified files have at least one changelog fragment (`--diff`)
+- Verifies PR numbers inside fragments match the pull request (`--pr`)
+
+### Release workflow
+
+Copy `.github/workflows/release.yml` to your repository, or reference the
+composite action directly. Trigger via the GitHub UI or CLI:
+
+```bash
+gh workflow run release.yml -f package=cardano-api
+gh workflow run release.yml -f package=cardano-api -f version=9.0.0.0
+```
+
+```yaml
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      package:
+        description: Package name to release (must match a project in .herald.yml)
+        required: true
+        type: string
+      version:
+        description: Explicit version (A.B.C.D). Leave empty to auto-compute.
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: cachix/install-nix-action@v30
+        with:
+          extra_nix_config: |
+            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
+            substituters = https://cache.iog.io/ https://cache.nixos.org/
+
+      - uses: input-output-hk/cardano-dev/herald/.github/actions/release@main
+        with:
+          package: ${{ inputs.package }}
+          version: ${{ inputs.version }}
+          # herald-ref: github:input-output-hk/cardano-dev  # default
+          # config: .herald.yml                               # default
+```
+
+The release action:
+1. Computes the next version (auto or explicit)
+2. Creates a `release/PACKAGE-VERSION` branch
+3. Batches changelog fragments, commits, and tags (`--commit-tag`)
+4. Pushes the branch and tag
+5. Opens a PR with the changes
+6. Creates a release changelog fragment for the next cycle
+7. Updates the PR body with signing instructions
+
+Since the commits are unsigned (created by `github-actions[bot]`), the PR body
+includes exact git commands for the maintainer to sign the commits before merging:
+
+```bash
+git fetch origin release/cardano-api-9.0.0.0
+git checkout release/cardano-api-9.0.0.0
+git rebase HEAD~2 --exec 'git commit --amend --no-edit -S'
+git tag -f cardano-api-9.0.0.0 HEAD~1
+git push --force-with-lease origin release/cardano-api-9.0.0.0
+git push --force origin cardano-api-9.0.0.0
+```
+
+## CLI reference
+
+```
+herald - changelog and versioning automation
+
+Usage: herald [-c|--config FILE] COMMAND
+
+Commands:
+  init       Scan the repository and generate .herald.yml
+  new        Create a changelog fragment (interactive or scripted)
+  validate   Validate fragments, check PR numbers, check diffs
+  batch      Collect fragments, update changelog and .cabal, remove fragments
+  next       Print the next version for a package
+```
+
+### Global options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-c`, `--config FILE` | `.herald.yml` | Path to herald config file |
+
+### `herald init`
+
+Scans the repository for `.cabal` files, detects the GitHub remote, and writes
+a `.herald.yml` config with discovered projects and default kinds. Also creates
+`.changes/_TEMPLATE.yml`.
+
+### `herald new`
+
+| Flag | Description |
+|------|-------------|
+| `-p`, `--project NAME` | Project name(s), comma-separated or repeated |
+| `-k`, `--kind KIND` | Kind(s), comma-separated or repeated |
+| `-d`, `--description TEXT` | Change description |
+| `--pr N` | PR number |
+
+If all flags are provided, creates the fragment non-interactively. Otherwise
+launches an interactive prompt with multi-select menus.
+
+### `herald validate`
+
+| Flag | Description |
+|------|-------------|
+| `[FILES...]` | Specific files to validate (default: all in changes dir) |
+| `--diff` | Check that modified projects have changelog fragments |
+| `--pr N` | Check that new fragments have this PR number |
+
+### `herald batch PACKAGE`
+
+| Flag | Description |
+|------|-------------|
+| `-v`, `--version A.B.C.D` | Explicit version (default: auto-compute) |
+| `--date YYYY-MM-DD` | Date for changelog header (default: today) |
+| `--commit` | Stage and commit batch changes |
+| `--commit-tag` | Stage, commit, and create a PACKAGE-VERSION tag |
+
+### `herald next PACKAGE`
+
+Prints the auto-computed next version to stdout. Useful for scripting.
+Exit code 1 if no version can be computed (e.g. no fragments).

--- a/herald/REQUIREMENTS.md
+++ b/herald/REQUIREMENTS.md
@@ -1,0 +1,215 @@
+# Changelog tooling requirements
+
+## Context
+
+This document captures requirements for replacing the in-house release scripts
+(`download-prs.sh`, `generate-pr-changelogs.sh`) with a file-based changelog tool.
+
+See: https://github.com/input-output-hk/cardano-dev/issues/17
+
+## Current process (status quo)
+
+- Contributors embed a YAML block in the PR description with `description`, `type`, and `projects`
+- At release time, a maintainer downloads all PRs from GitHub and generates markdown
+- Version bumps in `.cabal` files are manual
+- A separate `tag.sh` script handles tagging with safety checks
+
+### Pain points
+
+- Downloading all PRs is slow and requires network access
+- Depends on contributors correctly formatting YAML in PR descriptions (easy to get wrong)
+- Requires `jq`, `yq`, `gh` tooling
+- Custom scripts to maintain
+
+## Requirements
+
+### R1: File-based changelog fragments
+
+Each PR must include a changelog fragment file committed to the repo.
+This avoids parsing PR descriptions and eliminates merge conflicts on `CHANGELOG.md`.
+
+### R2: Multiple packages (mono-repo)
+
+The repo contains multiple packages, each with its own `CHANGELOG.md` and `.cabal` file:
+- `cardano-api`
+- `cardano-api-gen`
+- `cardano-rpc`
+- `cardano-wasm`
+
+A fragment must be associated with one or more packages.
+Release (batching + changelog assembly) is done per-package independently.
+
+### R3: PVP versioning with auto-bumping (four-part: A.B.C.D)
+
+Versions follow [Haskell PVP](https://pvp.haskell.org/), not SemVer.
+The tool must accept and produce 4-part version strings like `10.25.0.0` or `0.0.0.1`.
+
+Auto-bumping must be supported, based on the most significant kind across all unreleased
+fragments for a package. The mapping from kinds to PVP digits is:
+
+| Kind | PVP bump | Example (from `8.4.1.2`) |
+|------|----------|--------------------------|
+| `breaking` | Bump 2nd digit (A.**B**.0.0) | `8.5.0.0` |
+| `feature`, `compatible` | Bump 3rd digit (A.B.**C**.0) | `8.4.2.0` |
+| `bugfix`, `optimisation` | Bump 4th digit (A.B.C.**D**) | `8.4.1.3` |
+| non-notable only | Bump 4th digit (A.B.C.**D**) | `8.4.1.3` |
+
+The highest-significance kind wins. For example, if fragments contain both `breaking` and
+`bugfix`, the 2nd digit is bumped.
+
+The release workflow should support both:
+- **Auto mode** -- compute the next version from the current version + fragment kinds
+- **Explicit mode** -- maintainer specifies the exact version (e.g., `9.0.0.0` for a major Cardano release)
+
+The current version is read from the `version:` field in the project's `.cabal` file.
+
+### R4: Multiple kinds per entry (multi-select)
+
+Each changelog entry can have multiple kinds (comma-separated). Available kinds:
+
+| Kind | Appears in changelog |
+|------|---------------------|
+| `breaking` | yes |
+| `feature` | yes |
+| `compatible` | yes |
+| `bugfix` | yes |
+| `optimisation` | yes |
+| `refactoring` | no |
+| `test` | no |
+| `maintenance` | no |
+| `release` | no |
+| `documentation` | no |
+
+### R5: Non-notable kinds are hidden in changelog
+
+Entries where all kinds are non-notable (refactoring, test, maintenance, release, documentation)
+must not appear in the rendered changelog. If at least one notable kind is present, the entry is visible.
+
+### R6: PR number is recorded and validated
+
+Each fragment records the PR number. CI validates that the PR number in the fragment matches
+the actual PR number.
+
+### R7: Changelog fragments are mandatory
+
+Every PR must include a fragment. There is no opt-out mechanism (no `no-changelog` label).
+
+### R8: Automated release PR via GitHub Actions
+
+A workflow_dispatch action takes a package name and an optional PVP version string, then:
+1. Determines the next version -- either from the explicit input or auto-computed from
+   the current `.cabal` version + the most significant kind in unreleased fragments (see R3)
+2. Collects unreleased fragments for that package
+3. Generates the version's changelog section
+4. Updates the `version:` field in the package's `.cabal` file
+5. Creates a release commit and `PACKAGE-VERSION` tag
+6. Pushes to a `release/PACKAGE-VERSION` branch
+7. Opens a PR with the changes
+8. Creates a release changelog fragment for the next cycle
+9. Updates the PR body with commit signing instructions
+
+**Implementation:** Provided as a reusable composite GitHub Action at
+`.github/actions/release/action.yml` with an example workflow at
+`.github/workflows/release.yml`. Uses `--commit-tag` for atomic release commits.
+
+A separate validate action (`.github/actions/validate/action.yml`) runs on PRs to
+check fragment validity, PR number correctness, and that modified projects have fragments.
+
+### R9: `.cabal` version replacement on release
+
+When batching a release, the `version:` field in the relevant `.cabal` file is automatically
+updated to the new version.
+
+### R10: Changelog output format
+
+The rendered changelog should match the existing format:
+
+```markdown
+## 10.25.0.0 -- 2026-03-25
+
+- Description of the change
+  (bugfix, compatible)
+  [PR 1234](https://github.com/IntersectMBO/cardano-api/pull/1234)
+
+- Another change
+  (feature)
+  [PR 1235](https://github.com/IntersectMBO/cardano-api/pull/1235)
+```
+
+## Tool survey
+
+No existing tool satisfies all requirements out of the box. The core problem is that every
+tool with auto version bumping is hardwired to SemVer (3-part versions).
+
+### Evaluated tools
+
+| Tool | 4-part PVP | Fragments | Mono-repo | Multi-kind | Hidden kinds | Custom format | Auto bump | nixpkgs |
+|---|---|---|---|---|---|---|---|---|
+| **Towncrier** | yes (pass-through) | yes | yes | multi-file | yes (`showcontent`) | yes (Jinja2) | no | yes |
+| **Scriv** | yes (pass-through) | yes | no | yes (in-file) | partial | yes (Jinja2) | no | no |
+| **Reno** | yes (pass-through) | yes | no | yes (YAML) | no | limited (RST) | no | yes |
+| **Changie** | no (rejects) | yes | yes | no | workaround | yes (Go tmpl) | SemVer only | yes |
+| **git-cliff** | no (bump SemVer) | no | yes | n/a | n/a | yes (Tera) | SemVer only | yes |
+| **Knope** | no | yes | yes | yes | ? | limited | SemVer only | no |
+| **Changesets** | no | yes | yes | yes | no | yes | SemVer only | no |
+| **release-please** | custom code needed | no | yes | n/a | n/a | limited | SemVer only | no |
+
+### Towncrier -- best candidate
+
+Meets R1, R2, R5, R7, R10 natively:
+- File-based fragments (core design)
+- Mono-repo with per-package changelogs (via `[[tool.towncrier.section]]`)
+- Hidden kinds via `showcontent = false` per fragment type
+- Any version string (version-agnostic -- never parses versions)
+- Fully customizable output via Jinja2 templates
+- Available in nixpkgs (`python3Packages.towncrier`)
+
+**Gaps:**
+- **R3 (auto PVP bumping):** Towncrier does not bump versions at all. A custom script is needed
+  to read fragment kinds, determine the highest-significance kind, and compute the next PVP
+  version from the latest git tag.
+- **R4 (multi-kind per entry):** Towncrier encodes the kind in the fragment filename
+  (`123.bugfix.md`). A PR with multiple kinds creates multiple fragment files
+  (e.g., `123.bugfix.md` + `123.refactoring.md`). This works but is not single-file multi-select.
+- **R9 (`.cabal` replacement):** Towncrier does not modify `.cabal` files. The release script
+  must handle this.
+
+### Changie -- partial fit, blocking limitations
+
+Meets R1, R2, R10 natively. Has mono-repo projects and `.cabal` replacements built in.
+
+**Blockers:**
+- **R3:** Rejects 4-part PVP versions (`changie batch 0.0.0.1` fails with
+  `part string is not a supported version or version increment`).
+- **R4:** Built-in `kinds` is single-select only. Workaround: use a custom string field,
+  losing the interactive kind picker.
+- **R3 (auto bump):** Only supports SemVer `major`/`minor`/`patch`/`auto`.
+
+### Other tools -- ruled out
+
+- **git-cliff:** No file-based fragments (commit-based). SemVer-only bumping.
+- **Knope, Changesets:** SemVer-only. Not in nixpkgs.
+- **release-please:** No fragments. SemVer-only. Requires custom TypeScript for PVP.
+- **Scriv:** No mono-repo support. Not in nixpkgs.
+- **Reno:** No mono-repo support. RST-centric output.
+
+## Conclusion
+
+Every approach requires a custom PVP version-bumping script -- no tool provides this.
+The choice is which tool handles the fragment-to-changelog pipeline:
+
+| Approach | Pros | Cons |
+|----------|------|------|
+| **Towncrier + PVP script** | Battle-tested, Jinja2 templates, native hidden kinds, in nixpkgs | Multi-kind = multi-file, no `.cabal` replacement |
+| **Changie + wrapper** | Mono-repo projects, `.cabal` replacement, Go templates | Must work around SemVer-only `batch`, must work around single-select kinds |
+| **Custom script only** | Full control, PVP-native, no tool limitations | More code to write and maintain |
+
+## Decision
+
+A fully custom tool (Herald) was built. It handles all requirements natively: PVP 4-part
+versioning with auto-bumping, multi-select kinds, mono-repo projects, non-notable filtering,
+fragment validation, and automated release PR creation. Tagging is incorporated via
+`herald batch --commit-tag`, replacing the need for a separate `tag.sh` script.
+
+Herald is implemented in Haskell, built with nix (GHC 9.12.2), and distributed as a
+flake app at `github:input-output-hk/cardano-dev#herald`.

--- a/herald/app/Main.hs
+++ b/herald/app/Main.hs
@@ -1,0 +1,296 @@
+module Main where
+
+import Control.Exception (catch)
+import Data.Text qualified as T
+import Data.Time (Day, defaultTimeLocale, getCurrentTime, parseTimeM, utctDay)
+import Options.Applicative
+import System.Exit (exitFailure)
+import System.IO (hPutStrLn, stderr)
+
+import Herald.Command.Batch (BatchResult (..), CommitMode (..), batchPackage, commitBatchResult)
+import Herald.Command.Init (initConfig)
+import Herald.Command.New (NewOptions (..), createFragment, interactiveNew)
+import Herald.Command.Next (nextVersion)
+import Herald.Command.Validate (validateDiff, validateFiles, validatePR)
+import Herald.Config (loadConfig)
+import Herald.Fragment.Read (discoverFragmentPaths)
+import Herald.Pvp (Pvp, parsePvp, showPvp)
+import Herald.Types (Config (..), HeraldException (..), throwHerald)
+
+newtype GlobalOpts = GlobalOpts
+  { globalConfig :: FilePath
+  }
+
+data Command
+  = CmdInit
+  | CmdNew !NewOpts
+  | CmdValidate !ValidateOpts
+  | CmdBatch !BatchOpts
+  | CmdNext !NextOpts
+
+-- | Options for 'new'. All fields are optional to support interactive mode.
+data NewOpts = NewOpts
+  { newOptProjects :: ![String]
+  , newOptKinds :: ![String]
+  , newOptDescription :: !(Maybe String)
+  , newOptPR :: !(Maybe Int)
+  }
+
+data ValidateOpts = ValidateOpts
+  { validateFiles_ :: ![FilePath]
+  , validateDiff_ :: !Bool
+  , validatePR_ :: !(Maybe Int)
+  }
+
+data BatchOpts = BatchOpts
+  { batchPackage_ :: !String
+  , batchVersion :: !(Maybe Pvp)
+  , batchDate :: !(Maybe Day)
+  , batchCommitMode :: !CommitMode
+  }
+
+newtype NextOpts = NextOpts
+  { nextPackage :: String
+  }
+
+-------------------------------------------------------------------------------
+-- Parsers
+-------------------------------------------------------------------------------
+
+globalOptsParser :: Parser GlobalOpts
+globalOptsParser =
+  GlobalOpts
+    <$> strOption
+      ( long "config"
+          <> short 'c'
+          <> metavar "FILE"
+          <> value ".herald.yml"
+          <> help "Path to herald config file"
+      )
+
+newParser :: Parser NewOpts
+newParser =
+  NewOpts
+    <$> many
+      ( strOption
+          ( long "project"
+              <> short 'p'
+              <> metavar "NAME[,NAME]"
+              <> help "Project(s), comma-separated or repeated"
+          )
+      )
+    <*> many
+      ( strOption
+          (long "kind" <> short 'k' <> metavar "KIND[,KIND]" <> help "Kind(s), comma-separated or repeated")
+      )
+    <*> optional
+      ( strOption
+          ( long "description"
+              <> short 'd'
+              <> metavar "TEXT"
+              <> help "Change description (multiline via shell $'...\\n...')"
+          )
+      )
+    <*> optional (option auto (long "pr" <> metavar "N" <> help "PR number"))
+
+validateParser :: Parser ValidateOpts
+validateParser =
+  ValidateOpts
+    <$> many
+      ( argument
+          str
+          (metavar "[FILES...]" <> help "Changelog fragment files to validate (default: all unreleased)")
+      )
+    <*> switch
+      ( long "diff"
+          <> help "Check that projects with modified files have changelog fragments"
+      )
+    <*> optional
+      ( option
+          auto
+          ( long "pr"
+              <> metavar "N"
+              <> help "Check that new fragments on this branch have this PR number"
+          )
+      )
+
+batchParser :: Parser BatchOpts
+batchParser =
+  BatchOpts
+    <$> argument str (metavar "PACKAGE" <> help "Package name")
+    <*> optional
+      (option pvpReader (long "version" <> short 'v' <> metavar "A.B.C.D" <> help "Explicit version"))
+    <*> optional
+      ( option
+          dayReader
+          (long "date" <> metavar "YYYY-MM-DD" <> help "Date for the changelog section header (default: today)")
+      )
+    <*> commitModeParser
+
+commitModeParser :: Parser CommitMode
+commitModeParser =
+  flag' CommitTag (long "commit-tag" <> help "Commit batch changes and create a PACKAGE-VERSION tag")
+    <|> flag'
+      Commit
+      (long "commit" <> help "Commit batch changes (changelog, .cabal version, removed fragments)")
+    <|> pure NoCommit
+
+pvpReader :: ReadM Pvp
+pvpReader = eitherReader $ \s ->
+  maybe (Left "Invalid PVP version, expected A.B.C.D (e.g. 1.2.3.0)") Right $
+    parsePvp s
+
+dayReader :: ReadM Day
+dayReader = eitherReader $ \s ->
+  maybe (Left "Invalid date, expected YYYY-MM-DD") Right $
+    parseTimeM True defaultTimeLocale "%Y-%m-%d" s
+
+nextParser :: Parser NextOpts
+nextParser =
+  NextOpts
+    <$> argument str (metavar "PACKAGE" <> help "Package name")
+
+commandParser :: Parser Command
+commandParser =
+  subparser
+    ( command
+        "init"
+        ( info
+            (pure CmdInit <**> helper)
+            (progDesc "Scan the repository and generate .herald.yml with discovered projects")
+        )
+        <> command
+          "new"
+          ( info
+              (CmdNew <$> newParser <**> helper)
+              (progDesc "Create a changelog fragment (interactive unless all flags provided)")
+          )
+        <> command
+          "validate"
+          ( info
+              (CmdValidate <$> validateParser <**> helper)
+              ( progDesc
+                  "Validate changelog fragments, check PR numbers match (--pr), and ensure modified projects have changelog fragments (--diff)"
+              )
+          )
+        <> command
+          "batch"
+          ( info
+              (CmdBatch <$> batchParser <**> helper)
+              ( progDesc
+                  "Collect changelog fragments for PACKAGE, update the changelog file with a new section, bump the .cabal version, and remove processed fragments"
+              )
+          )
+        <> command
+          "next"
+          ( info
+              (CmdNext <$> nextParser <**> helper)
+              ( progDesc
+                  "Print the next version for PACKAGE by applying the highest bump from unreleased changelog fragments to the current .cabal version"
+              )
+          )
+    )
+
+opts :: ParserInfo (GlobalOpts, Command)
+opts =
+  info
+    ((,) <$> globalOptsParser <*> commandParser <**> helper)
+    ( fullDesc
+        <> progDesc "Manage changelog fragments, version bumps, and releases for Haskell projects"
+        <> header "herald - changelog and versioning automation"
+    )
+
+-------------------------------------------------------------------------------
+-- Main
+-------------------------------------------------------------------------------
+
+main :: IO ()
+main = do
+  (globalOpts, cmd) <- execParser opts
+  case cmd of
+    CmdInit -> do
+      path <- initConfig "." (globalConfig globalOpts)
+      putStrLn $ "Created config: " <> path
+      putStrLn "Please review the generated configuration and adjust as needed."
+    _ -> do
+      configResult <- loadConfig $ globalConfig globalOpts
+      config <-
+        either (\err -> throwHerald $ "Loading config: " <> err) pure configResult
+      runCommand config cmd
+        `catch` \(HeraldException msg) -> do
+          hPutStrLn stderr $ "Error: " <> msg
+          exitFailure
+
+runCommand :: Config -> Command -> IO ()
+runCommand config cmd = case cmd of
+  CmdInit -> pure ()
+  CmdNew newOpts -> runNew config newOpts
+  CmdValidate valOpts -> do
+    fileErrors <- do
+      files <- case validateFiles_ valOpts of
+        [] -> discoverFragmentPaths config "."
+        explicit -> pure explicit
+      validateFiles config files
+    diffErrors <-
+      if validateDiff_ valOpts
+        then validateDiff config "."
+        else pure []
+    prErrors <- case validatePR_ valOpts of
+      Just pr -> validatePR config "." pr
+      Nothing -> pure []
+    let errors = fileErrors <> diffErrors <> prErrors
+    if null errors
+      then putStrLn "All changelog fragments valid."
+      else do
+        throwHerald . T.unpack $ T.intercalate "\n" errors
+  CmdBatch batchOpts -> do
+    let version = batchVersion batchOpts
+    day <- maybe (utctDay <$> getCurrentTime) pure $ batchDate batchOpts
+    mResult <- batchPackage config "." (T.pack $ batchPackage_ batchOpts) version day
+    case mResult of
+      Nothing -> pure ()
+      Just result -> do
+        putStrLn $ "Batched " <> batchPackage_ batchOpts <> " " <> showPvp (batchResultVersion result)
+        putStrLn $ "  Changelog: " <> batchResultChangelog result
+        maybe (pure ()) (\cf -> putStrLn $ "  Cabal file: " <> cf) $ batchResultCabalFile result
+        putStrLn "  Consumed changelog fragments:"
+        mapM_ (\f -> putStrLn $ "    " <> f) $ batchResultFragments result
+        commitBatchResult "." result $ batchCommitMode batchOpts
+  CmdNext nextOpts -> do
+    result <- nextVersion config "." (T.pack $ nextPackage nextOpts)
+    maybe
+      ( throwHerald $
+          "Could not compute next version for "
+            <> nextPackage nextOpts
+            <> ". Are there unreleased changelog fragments?"
+      )
+      (putStrLn . showPvp)
+      result
+
+-- | Run the 'new' command. If all required options are provided, create fragments
+-- directly. Otherwise, enter interactive mode.
+runNew :: Config -> NewOpts -> IO ()
+runNew config newOpts = do
+  let projects = splitCommas $ newOptProjects newOpts
+      kinds = splitCommas $ newOptKinds newOpts
+  optsList <- case (projects, kinds, newOptDescription newOpts, newOptPR newOpts) of
+    (_ : _, _ : _, Just desc, Just pr) ->
+      pure [NewOptions (T.pack p) (map T.pack kinds) (T.pack desc) pr | p <- projects]
+    _ -> interactiveNew config
+  mapM_ (createAndReport config) optsList
+
+createAndReport :: Config -> NewOptions -> IO ()
+createAndReport config fragmentOpts = do
+  path <- createFragment config "." fragmentOpts
+  putStrLn $ "Created changelog fragment: " <> path
+
+-- | Split a list of strings on commas and flatten.
+-- e.g. @[\"a,b\", \"c\"] -> [\"a\", \"b\", \"c\"]@
+splitCommas :: [String] -> [String]
+splitCommas = concatMap (map strip . splitOn ',')
+ where
+  splitOn _ [] = []
+  splitOn delim s = case break (== delim) s of
+    (part, []) -> [part]
+    (part, _ : rest) -> part : splitOn delim rest
+  strip = reverse . dropWhile (== ' ') . reverse . dropWhile (== ' ')

--- a/herald/cabal.project
+++ b/herald/cabal.project
@@ -1,0 +1,5 @@
+packages: .
+
+constraints:
+  -- haskell.nix patch does not work for 1.6.8
+  any.crypton-x509-system < 1.6.8

--- a/herald/fourmolu.yaml
+++ b/herald/fourmolu.yaml
@@ -1,0 +1,62 @@
+indentation: 2
+column-limit: 100
+function-arrows: leading
+comma-style: leading
+import-export-style: leading
+import-grouping:
+  - rules:
+    - glob: Cardano.Api**
+    - glob: Cardano.Rpc**
+  - rules:
+    - glob: Cardano**
+    - glob: Ouroboros**
+    - glob: PlutusCore**
+    - glob: PlutusLedgerApi**
+  - rules:
+    - glob: Prelude**
+    - glob: RIO**
+  - rules:
+    - glob: Control**
+    - glob: Codec**
+    - glob: Data**
+    - glob: Formatting**
+    - glob: GHC**
+    - glob: Lens**
+    - glob: Network**
+    - glob: Numeric**
+    - glob: Options**
+    - glob: Prettyprinter**
+    - glob: System**
+    - glob: Text**
+  - rules:
+    - glob: Test.Gen.Cardano.Api**
+  - rules:
+    - glob: Test.Cardano**
+    - glob: Test.Gen.Cardano**
+  - rules:
+    - glob: Hedgehog**
+    - glob: Test**
+  - name: "The rest"
+    rules:
+    - match: all
+      priority: 100
+indent-wheres: false
+record-brace-space: false
+newlines-between-decls: 1
+haddock-style: single-line
+haddock-style-module:
+let-style: auto
+in-style: right-align
+single-constraint-parens: never
+single-deriving-parens: never
+sort-constraints: false
+sort-derived-classes: false
+sort-deriving-clauses: false
+trailing-section-operators: true
+unicode: never
+respectful: false
+fixities:
+  - infixl 1 &
+  - infixr 4 .~
+reexports: []
+local-modules: []

--- a/herald/herald.cabal
+++ b/herald/herald.cabal
@@ -1,0 +1,186 @@
+cabal-version: 3.12
+name: herald
+version: 0.1.0.0
+synopsis: Changelog and release automation for PVP-versioned Haskell projects
+license: Apache-2.0
+author: Input Output Global
+maintainer: operations@iohk.io
+build-type: Simple
+
+common warnings
+  ghc-options:
+    -Wall
+    -Wredundant-constraints
+    -Wincomplete-record-updates
+    -Wincomplete-uni-patterns
+
+common lang
+  default-language: GHC2021
+  default-extensions:
+    LambdaCase
+    OverloadedStrings
+
+library
+  import: warnings, lang
+  hs-source-dirs: src
+  default-extensions:
+    NoImplicitPrelude
+
+  autogen-modules:
+    PackageInfo_herald
+    Paths_herald
+
+  other-modules:
+    PackageInfo_herald
+    Paths_herald
+
+  exposed-modules:
+    Herald.Cabal
+    Herald.Changelog
+    Herald.Command.Batch
+    Herald.Command.Init
+    Herald.Command.New
+    Herald.Command.Next
+    Herald.Command.Validate
+    Herald.Config
+    Herald.Fragment
+    Herald.Fragment.Read
+    Herald.Fragment.Render
+    Herald.Git
+    Herald.Git.Repository
+    Herald.Pvp
+    Herald.Terminal
+    Herald.Types
+
+  build-depends:
+    aeson,
+    base >=4.14 && <5,
+    containers,
+    directory,
+    filepath,
+    haskeline,
+    optparse-applicative,
+    process,
+    rio,
+    safe-exceptions,
+    text,
+    time,
+    transformers,
+    yaml,
+
+executable herald
+  import: warnings, lang
+  hs-source-dirs: app
+  main-is: Main.hs
+  autogen-modules:
+    PackageInfo_herald
+    Paths_herald
+
+  other-modules:
+    PackageInfo_herald
+    Paths_herald
+
+  build-depends:
+    base >=4.14 && <5,
+    herald,
+    optparse-applicative,
+    text,
+    time,
+
+library herald-test-lib
+  import: warnings, lang
+  visibility: private
+  hs-source-dirs: test-lib
+  autogen-modules:
+    PackageInfo_herald
+    Paths_herald
+
+  other-modules:
+    PackageInfo_herald
+    Paths_herald
+
+  exposed-modules:
+    Test.Herald.Assertions
+    Test.Herald.Fixtures
+
+  build-depends:
+    base >=4.14 && <5,
+    containers,
+    hedgehog,
+    herald,
+    text,
+    time,
+
+test-suite herald-test
+  import: warnings, lang
+  type: exitcode-stdio-1.0
+  hs-source-dirs: test
+  main-is: Main.hs
+  autogen-modules:
+    PackageInfo_herald
+    Paths_herald
+
+  other-modules:
+    PackageInfo_herald
+    Paths_herald
+    Test.Herald.Cabal
+    Test.Herald.Changelog
+    Test.Herald.Config
+    Test.Herald.Fragment
+    Test.Herald.Git
+    Test.Herald.Pvp
+    Test.Herald.Render
+    Test.Herald.Terminal
+
+  build-depends:
+    base >=4.14 && <5,
+    bytestring,
+    containers,
+    directory,
+    filepath,
+    hedgehog,
+    hedgehog-extras,
+    herald,
+    herald:herald-test-lib,
+    tasty,
+    tasty-hedgehog,
+    temporary,
+    text,
+    time,
+    yaml,
+
+test-suite herald-test-e2e
+  import: warnings, lang
+  type: exitcode-stdio-1.0
+  hs-source-dirs: test-e2e
+  main-is: Main.hs
+  autogen-modules:
+    PackageInfo_herald
+    Paths_herald
+
+  other-modules:
+    PackageInfo_herald
+    Paths_herald
+    Test.Herald.E2E.Batch
+    Test.Herald.E2E.Fixtures
+    Test.Herald.E2E.Fragment
+    Test.Herald.E2E.Init
+    Test.Herald.E2E.Next
+    Test.Herald.E2E.Validate
+
+  build-depends:
+    base >=4.14 && <5,
+    containers,
+    directory,
+    filepath,
+    hedgehog,
+    hedgehog-extras,
+    herald,
+    herald:herald-test-lib,
+    process,
+    tasty,
+    tasty-hedgehog,
+    temporary,
+    text,
+    time,
+    yaml,

--- a/herald/src/Herald/Cabal.hs
+++ b/herald/src/Herald/Cabal.hs
@@ -1,0 +1,32 @@
+module Herald.Cabal
+  ( readCabalVersion
+  , writeCabalVersion
+  )
+where
+
+import RIO
+
+import Data.List (find)
+import Data.Text qualified as T
+
+import Herald.Pvp (Pvp, parsePvp, showPvp)
+
+-- | Read the version from a .cabal file.
+readCabalVersion :: FilePath -> IO (Maybe Pvp)
+readCabalVersion path = do
+  content <- readFileUtf8 path
+  pure $ do
+    line <- find (T.isPrefixOf "version:") . map (T.filter (/= '\r')) $ T.lines content
+    let versionStr = T.strip . T.drop (T.length "version:") $ line
+    parsePvp $ T.unpack versionStr
+
+-- | Write a new version to a .cabal file, replacing the existing version: line.
+writeCabalVersion :: FilePath -> Pvp -> IO ()
+writeCabalVersion path version = do
+  content <- readFileUtf8 path
+  let newContent = T.unlines . map (replaceLine . T.filter (/= '\r')) $ T.lines content
+  writeFileUtf8 path newContent
+ where
+  replaceLine line
+    | T.isPrefixOf "version:" line = "version: " <> T.pack (showPvp version)
+    | otherwise = line

--- a/herald/src/Herald/Changelog.hs
+++ b/herald/src/Herald/Changelog.hs
@@ -1,0 +1,18 @@
+module Herald.Changelog
+  ( prependSection
+  )
+where
+
+import RIO
+
+import Data.Text qualified as T
+
+-- | Prepend a changelog section before the first existing ## header.
+-- If no ## header exists, appends the section at the end.
+prependSection :: FilePath -> Text -> IO ()
+prependSection path section = do
+  content <- readFileUtf8 path
+  let ls = map (T.filter (/= '\r')) $ T.lines content
+      (before, after) = break (T.isPrefixOf "## ") ls
+      newContent = T.unlines $ before ++ T.lines section ++ [""] ++ after
+  writeFileUtf8 path newContent

--- a/herald/src/Herald/Command/Batch.hs
+++ b/herald/src/Herald/Command/Batch.hs
@@ -1,0 +1,151 @@
+module Herald.Command.Batch
+  ( batchPackage
+  , BatchResult (..)
+  , CommitMode (..)
+  , commitBatchResult
+  , computeMaxBump
+  )
+where
+
+import RIO
+
+import Data.Map.Strict qualified as Map
+import Data.Text qualified as T
+import Data.Text.IO qualified as TIO
+import Data.Time (Day)
+import System.Directory (removeFile)
+import System.FilePath ((</>))
+
+import Herald.Cabal (readCabalVersion, writeCabalVersion)
+import Herald.Changelog (prependSection)
+import Herald.Fragment (validateFragment)
+import Herald.Fragment.Read (readProjectFragments)
+import Herald.Fragment.Render (renderSection)
+import Herald.Git (gitAdd, gitCommit, gitTag)
+import Herald.Pvp (Pvp (..), bumpPvp, showPvp)
+import Herald.Types (Config (..), Fragment (..), KindDef (..), ProjectConfig (..), throwHerald)
+
+-- | Result of a batch operation, for reporting to the user.
+data BatchResult = BatchResult
+  { batchResultVersion :: !Pvp
+  , batchResultPackage :: !Text
+  , batchResultFragments :: ![FilePath]
+  , batchResultChangelog :: !FilePath
+  , batchResultCabalFile :: !(Maybe FilePath)
+  , batchResultChangesDir :: !FilePath
+  }
+  deriving Show
+
+-- | Whether to commit and/or tag after batching.
+data CommitMode = NoCommit | Commit | CommitTag
+  deriving (Eq, Show)
+
+-- | Batch changelog fragments for a package: compute version, render section,
+-- prepend to CHANGELOG.md, update .cabal version, and remove processed fragments.
+-- Returns 'Nothing' (with a warning) when no fragments exist for the package.
+batchPackage :: Config -> FilePath -> Text -> Maybe Pvp -> Day -> IO (Maybe BatchResult)
+batchPackage config baseDir package explicitVersion day = do
+  projectConfig <-
+    maybe (throwHerald $ "Unknown project: " <> T.unpack package) pure
+      . Map.lookup package
+      $ configProjects config
+  let changesDir = baseDir </> configChangesDir config
+
+  packagePairs <- readProjectFragments config baseDir package
+
+  if null packagePairs
+    then do
+      TIO.hPutStrLn stderr
+        $ "Warning: no changelog fragments found for "
+        <> package
+        <> "; nothing to do"
+      pure Nothing
+    else do
+      -- Validate fragments before modifying anything
+      let errors =
+            concatMap
+              (\(file, frag) -> map (\e -> T.pack file <> ": " <> e) $ validateFragment config frag)
+              packagePairs
+      unless (null errors)
+        . throwHerald
+        . T.unpack
+        $ T.intercalate "\n" errors
+
+      let packageFragments = map snd packagePairs
+
+      -- Compute version
+      version <- maybe (autoVersion projectConfig packageFragments) pure explicitVersion
+
+      -- Warn if explicit version is a downgrade
+      forM_ (projectCabalFile projectConfig) $ \cf -> do
+        currentVersion <- readCabalVersion (baseDir </> cf)
+        forM_ currentVersion $ \cv ->
+          when (version < cv)
+            . throwHerald
+            $ "Version "
+            <> showPvp version
+            <> " is lower than current "
+            <> showPvp cv
+            <> " in "
+            <> cf
+
+      -- Render section and prepend to changelog
+      let section = renderSection config version day packageFragments
+      prependSection (baseDir </> projectChangelog projectConfig) section
+
+      -- Update .cabal version (if cabal-file is configured)
+      forM_ (projectCabalFile projectConfig) $ \cf ->
+        writeCabalVersion (baseDir </> cf) version
+
+      -- Remove processed fragment files
+      forM_ packagePairs $ \(file, _) ->
+        removeFile $ changesDir </> file
+
+      pure
+        . Just
+        $ BatchResult
+          { batchResultVersion = version
+          , batchResultPackage = package
+          , batchResultFragments = map fst packagePairs
+          , batchResultChangelog = baseDir </> projectChangelog projectConfig
+          , batchResultCabalFile = (baseDir </>) <$> projectCabalFile projectConfig
+          , batchResultChangesDir = configChangesDir config
+          }
+ where
+  autoVersion projectConfig packageFragments = do
+    cabalPath <-
+      maybe (throwHerald "No cabal-file configured; use --version to set version explicitly") pure
+        $ projectCabalFile projectConfig
+    currentVersion <-
+      readCabalVersion (baseDir </> cabalPath)
+        >>= maybe (throwHerald "Could not read current version from .cabal") pure
+    pure . bumpPvp (computeMaxBump config packageFragments) $ currentVersion
+
+-- | Compute the maximum bump level from a list of fragments.
+computeMaxBump :: Config -> [Fragment] -> Pvp
+computeMaxBump config frags =
+  let allKinds = concatMap fragmentKinds frags
+      bumps = mapMaybe (fmap kindBump . (`Map.lookup` configKinds config)) allKinds
+   in case bumps of
+        [] -> Pvp (0 :| [0, 0, 1]) -- default: patch bump
+        b : bs -> foldl' max b bs
+
+-- | Stage batch changes, commit, and optionally tag.
+commitBatchResult :: FilePath -> BatchResult -> CommitMode -> IO ()
+commitBatchResult _ _ NoCommit = pure ()
+commitBatchResult baseDir result mode = do
+  let changesDir = batchResultChangesDir result
+      fragmentPaths = map (changesDir </>) $ batchResultFragments result
+      filesToStage =
+        fragmentPaths
+          <> [batchResultChangelog result]
+          <> maybeToList (batchResultCabalFile result)
+      pkg = T.unpack $ batchResultPackage result
+      ver = showPvp $ batchResultVersion result
+      msg = "Release " <> pkg <> "-" <> ver
+
+  gitAdd baseDir filesToStage
+  gitCommit baseDir msg
+
+  when (mode == CommitTag)
+    $ gitTag baseDir (pkg <> "-" <> ver)

--- a/herald/src/Herald/Command/Init.hs
+++ b/herald/src/Herald/Command/Init.hs
@@ -1,0 +1,188 @@
+module Herald.Command.Init
+  ( initConfig
+  )
+where
+
+import RIO
+
+import Control.Applicative (empty)
+import Control.Monad.Trans.Maybe (MaybeT (..), runMaybeT)
+import Data.Map.Strict qualified as Map
+import Data.Text qualified as T
+import System.Directory (createDirectoryIfMissing, doesDirectoryExist, doesFileExist, listDirectory)
+import System.FilePath (dropExtension, takeExtension, (</>))
+
+import Herald.Git (detectGitRepo)
+import Herald.Pvp (showPvp)
+import Herald.Types (Config (..), KindDef (..), ProjectConfig (..), defaultKinds, throwHerald)
+
+-- | Write text to a file with explicit UTF-8 encoding, avoiding locale issues.
+writeUtf8 :: FilePath -> Text -> IO ()
+writeUtf8 path = writeFileBinary path . encodeUtf8
+
+-- | Generate a default herald config file by scanning the repository.
+-- Discovers top-level directories (and root) as projects, then writes a commented YAML config.
+initConfig :: FilePath -> FilePath -> IO FilePath
+initConfig baseDir configPath = do
+  exists <- doesFileExist configPath
+  when exists
+    . throwHerald
+    $ configPath
+    <> " already exists; refusing to overwrite"
+
+  gitRepo <-
+    detectGitRepo baseDir
+      >>= maybe (throwHerald "Could not detect origin remote; set git-repo manually in .herald.yml") pure
+  projects <- discoverProjects baseDir
+
+  let config =
+        Config
+          { configGitRepo = gitRepo
+          , configChangesDir = ".changes"
+          , configKinds = defaultKinds
+          , configProjects = projects
+          }
+
+  writeUtf8 configPath $ renderCommentedConfig config
+
+  -- Create the changes directory with a template fragment
+  let changesDir = baseDir </> configChangesDir config
+      templatePath = changesDir </> "_TEMPLATE.yml"
+  createDirectoryIfMissing True changesDir
+  writeUtf8 templatePath renderTemplate
+
+  pure configPath
+
+-- | Render a Config as YAML with explanatory comments.
+renderCommentedConfig :: Config -> Text
+renderCommentedConfig config =
+  T.unlines
+    $ [ "# Herald configuration"
+      , "# Changelog and release automation for PVP-versioned Haskell projects"
+      , ""
+      , "# Git repository URL (used for PR links in changelogs)"
+      , "git-repo: " <> configGitRepo config
+      , ""
+      , "# Directory for changelog fragments, relative to repo root"
+      , "# Fragments are YAML files created by 'herald new' and consumed by 'herald batch'"
+      , "changes-dir: " <> T.pack (configChangesDir config)
+      , ""
+      , "# Change kinds and their properties"
+      , "#"
+      , "# Each kind defines:"
+      , "#   notable: if true (default), changes of this kind appear in the changelog"
+      , "#           if false, they still bump the version but are omitted from the changelog text"
+      , "#   bump:    PVP version component to bump when this kind is present"
+      , "#           0.1.0.0 = bump 2nd component (breaking changes)"
+      , "#           0.0.1.0 = bump 3rd component (features, compatible changes)"
+      , "#           0.0.0.1 = bump 4th component (patches, internal changes)"
+      , "#"
+      , "# The highest bump across all fragment kinds determines the final version bump."
+      , "kinds:"
+      ]
+    <> renderKinds (configKinds config)
+    <> [ ""
+       , "# Projects in this repository"
+       , "#"
+       , "# Each project needs:"
+       , "#   changelog:  path to the project's CHANGELOG.md (relative to repo root)"
+       , "#   cabal-file: (optional) path to the project's .cabal file (version is read/updated here)"
+       , "projects:"
+       ]
+    <> renderProjects (configProjects config)
+
+renderKinds :: Map Text KindDef -> [Text]
+renderKinds = concatMap renderKind . Map.toAscList
+ where
+  renderKind (name, kd) =
+    ["  " <> name <> ":"]
+      <> ["    notable: false" | not $ kindNotable kd]
+      <> ["    bump: " <> T.pack (showPvp $ kindBump kd)]
+      <> maybe [] (\d -> ["    description: " <> d]) (kindDescription kd)
+
+renderProjects :: Map Text ProjectConfig -> [Text]
+renderProjects = concatMap renderProject . Map.toAscList
+ where
+  renderProject (name, pc) =
+    [ "  " <> name <> ":"
+    , "    changelog: " <> T.pack (projectChangelog pc)
+    ]
+      <> maybe [] (\cf -> ["    cabal-file: " <> T.pack cf]) (projectCabalFile pc)
+
+-- | Render a template changelog fragment with example values.
+renderTemplate :: Text
+renderTemplate =
+  T.unlines
+    [ "# Changelog fragment template - copy this file and fill in the fields."
+    , "# Or use 'herald new' for interactive creation."
+    , "#"
+    , "# Files starting with _ are ignored by herald."
+    , "#"
+    , "# Available projects and kinds are defined in .herald.yml"
+    , ""
+    , "# Which project this change belongs to (see 'projects' in .herald.yml)"
+    , "project: my-project"
+    , "# Pull request number associated with this change"
+    , "pr: 0"
+    , "# One or more change kinds (see 'kinds' in .herald.yml)"
+    , "kind:"
+    , "  - bugfix"
+    , "description: |"
+    , "  Describe your change here."
+    ]
+
+-- | Scan the base directory for projects.
+-- Checks the root directory first (single-project repo), then all top-level subdirectories.
+-- Hidden directories (starting with @.@) are excluded.
+discoverProjects :: FilePath -> IO (Map Text ProjectConfig)
+discoverProjects baseDir = do
+  rootProject <- probeRootProject baseDir
+  maybe discoverSubProjects (pure . Map.fromList . pure) rootProject
+ where
+  discoverSubProjects = do
+    entries <- filter (not . isHidden) <$> listDirectory baseDir
+    subProjects <- catMaybes <$> traverse (probeSubProject baseDir) entries
+    pure $ Map.fromList subProjects
+  isHidden ('.' : _) = True
+  isHidden _ = False
+
+-- | Check if the root directory itself is a single project (has exactly one .cabal file).
+probeRootProject :: FilePath -> IO (Maybe (Text, ProjectConfig))
+probeRootProject baseDir = do
+  cabalFile <- findSingleCabalFile baseDir
+  pure $ do
+    cf <- cabalFile
+    let name = T.pack $ dropExtension cf
+    guard $ not $ T.null name
+    Just
+      ( name
+      , ProjectConfig
+          { projectChangelog = "CHANGELOG.md"
+          , projectCabalFile = Just cf
+          }
+      )
+
+-- | Probe a subdirectory as a project.
+-- All non-hidden directories are treated as projects. A .cabal file is detected if present.
+probeSubProject :: FilePath -> FilePath -> IO (Maybe (Text, ProjectConfig))
+probeSubProject baseDir entry = runMaybeT $ do
+  guard =<< liftIO (doesDirectoryExist $ baseDir </> entry)
+  cabalFile <- liftIO . findSingleCabalFile $ baseDir </> entry
+  let name = maybe (T.pack entry) (T.pack . dropExtension) cabalFile
+  guard . not $ T.null name
+  pure
+    ( name
+    , ProjectConfig
+        { projectChangelog = entry </> "CHANGELOG.md"
+        , projectCabalFile = fmap (entry </>) cabalFile
+        }
+    )
+
+-- | Find exactly one @.cabal@ file in a directory. Returns 'Nothing' if zero or multiple.
+findSingleCabalFile :: FilePath -> IO (Maybe FilePath)
+findSingleCabalFile dir = runMaybeT $ do
+  guard =<< liftIO (doesDirectoryExist dir)
+  files <- filter ((== ".cabal") . takeExtension) <$> liftIO (listDirectory dir)
+  case files of
+    [f] | not . null $ dropExtension f -> pure f
+    _ -> empty

--- a/herald/src/Herald/Command/New.hs
+++ b/herald/src/Herald/Command/New.hs
@@ -1,0 +1,108 @@
+module Herald.Command.New
+  ( NewOptions (..)
+  , createFragment
+  , interactiveNew
+  )
+where
+
+import RIO
+
+import Data.Char (isAlphaNum)
+import Data.List (sort)
+import Data.Map.Strict qualified as Map
+import Data.Text qualified as T
+import Data.Text.IO qualified as TIO
+import Data.Time (defaultTimeLocale, formatTime, getCurrentTime)
+import Data.Yaml qualified as Yaml
+import System.Directory (createDirectoryIfMissing)
+import System.FilePath ((</>))
+
+import Herald.Fragment (validateFragment)
+import Herald.Fragment.Read (readProjectFragments)
+import Herald.Git (currentBranch, userNick)
+import Herald.Terminal (promptInt, promptMultiLine, promptMultiSelect)
+import Herald.Types (Config (..), Fragment (..), KindDef (..), throwHerald)
+
+data NewOptions = NewOptions
+  { newProject :: !Text
+  , newKinds :: ![Text]
+  , newDescription :: !Text
+  , newPR :: !Int
+  }
+  deriving (Eq, Show)
+
+-- | Create a new changelog fragment file.
+-- Uses scriv-style naming: @{YYYYMMDD_HHMMSS}_{user}_{branch}.yml@.
+-- Empty components (no user, no branch) are dropped.
+createFragment :: Config -> FilePath -> NewOptions -> IO FilePath
+createFragment config baseDir opts = do
+  let frag = Fragment (newProject opts) (newKinds opts) (newDescription opts) (newPR opts)
+      errors = validateFragment config frag
+  unless (null errors)
+    . throwHerald
+    $ "Invalid fragment: "
+    <> T.unpack (T.intercalate ", " errors)
+
+  -- Check for existing fragment with same PR and project
+  existing <- readProjectFragments config baseDir (newProject opts)
+  case filter (\(_, f) -> fragmentPR f == newPR opts) existing of
+    (path, _) : _ ->
+      throwHerald
+        $ "A fragment for PR "
+        <> show (newPR opts)
+        <> " already exists: "
+        <> configChangesDir config
+        <> "/"
+        <> path
+        <> " -- update that file instead"
+    [] -> pure ()
+
+  filename <- generateFilename $ newProject opts
+  let outDir = baseDir </> configChangesDir config
+      outPath = outDir </> filename
+
+  createDirectoryIfMissing True outDir
+  Yaml.encodeFile outPath frag
+  pure outPath
+
+-- | Interactive mode: prompt the user for all fragment fields.
+-- Returns one 'NewOptions' per selected project.
+interactiveNew :: Config -> IO [NewOptions]
+interactiveNew config = do
+  let projectNames = sort . Map.keys $ configProjects config
+      kindPairs = Map.toAscList $ configKinds config
+      formatKind (name, kd) = case kindDescription kd of
+        Just desc -> T.unpack name <> " - " <> T.unpack desc
+        Nothing -> T.unpack name
+
+  projects <- promptMultiSelect "project" projectNames T.unpack
+  TIO.hPutStrLn stdout $ "  Selected: " <> T.intercalate ", " projects
+
+  kinds <- map fst <$> promptMultiSelect "kind" kindPairs formatKind
+  TIO.hPutStrLn stdout $ "  Selected: " <> T.intercalate ", " kinds
+
+  description <- promptMultiLine "Description"
+  prNumber <- promptInt "PR number"
+
+  pure [NewOptions p kinds description prNumber | p <- projects]
+
+-------------------------------------------------------------------------------
+-- Filename generation
+-------------------------------------------------------------------------------
+
+-- | Generate a scriv-style filename: @{timestamp}_{project}_{user}_{branch}.yml@.
+-- Empty components are dropped so the name stays clean.
+generateFilename :: Text -> IO FilePath
+generateFilename project = do
+  now <- getCurrentTime
+  let timestamp = formatTime defaultTimeLocale "%Y%m%d_%H%M%S" now
+      projectSlug = sanitise $ T.unpack project
+  nick <- userNick
+  branch <- currentBranch
+  let parts = filter (not . null) [timestamp, projectSlug, nick, branch]
+  pure $ joinWith "_" parts <> ".yml"
+ where
+  sanitise = map (\c -> if isAlphaNum c || c == '_' || c == '-' then c else '_')
+  joinWith _ [] = ""
+  joinWith _ [x] = x
+  joinWith sep (x : xs) = x <> sep <> joinWith sep xs

--- a/herald/src/Herald/Command/Next.hs
+++ b/herald/src/Herald/Command/Next.hs
@@ -1,0 +1,50 @@
+module Herald.Command.Next
+  ( nextVersion
+  )
+where
+
+import RIO
+
+import Data.Map.Strict qualified as Map
+import Data.Text qualified as T
+import System.FilePath ((</>))
+
+import Herald.Cabal (readCabalVersion)
+import Herald.Command.Batch (computeMaxBump)
+import Herald.Fragment (validateFragment)
+import Herald.Fragment.Read (readProjectFragments)
+import Herald.Pvp (Pvp, bumpPvp)
+import Herald.Types (Config (..), ProjectConfig (..), throwHerald)
+
+-- | Compute the next version for a package based on unreleased fragments.
+-- Validates all fragments first so that invalid fragments (unknown kinds, etc.)
+-- cause a failure rather than being silently ignored by 'computeMaxBump'.
+nextVersion :: Config -> FilePath -> Text -> IO (Maybe Pvp)
+nextVersion config baseDir package = do
+  projectConfig <-
+    maybe (throwHerald $ "Unknown project: " <> T.unpack package) pure
+      . Map.lookup package
+      $ configProjects config
+
+  currentVersion <-
+    maybe (pure Nothing) (readCabalVersion . (baseDir </>)) $ projectCabalFile projectConfig
+
+  packagePairs <- readProjectFragments config baseDir package
+
+  -- Validate fragments before computing the version, matching batchPackage behaviour
+  let errors =
+        concatMap
+          (\(file, frag) -> map (\e -> T.pack file <> ": " <> e) $ validateFragment config frag)
+          packagePairs
+  unless (null errors)
+    . throwHerald
+    . T.unpack
+    $ T.intercalate "\n" errors
+
+  let packageFragments = map snd packagePairs
+
+  pure $ do
+    cv <- currentVersion
+    _ : _ <- Just packageFragments
+    let maxBump = computeMaxBump config packageFragments
+    Just $ bumpPvp maxBump cv

--- a/herald/src/Herald/Command/Validate.hs
+++ b/herald/src/Herald/Command/Validate.hs
@@ -1,0 +1,132 @@
+module Herald.Command.Validate
+  ( validateFiles
+  , validateDiff
+  , validatePR
+  )
+where
+
+import RIO
+
+import Data.List (isPrefixOf)
+import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
+import Data.Text qualified as T
+import Data.Yaml qualified as Yaml
+import System.FilePath (takeDirectory, takeExtension, takeFileName, (</>))
+
+import Herald.Fragment (validateFragment)
+import Herald.Git (addedFiles, changedFiles, findForkPoint)
+import Herald.Types (Config (..), Fragment (..), ProjectConfig (..))
+
+-- | Validate a list of fragment files against the config.
+-- Returns a list of error messages. Empty list means all valid.
+validateFiles :: Config -> [FilePath] -> IO [Text]
+validateFiles config paths = do
+  results <- forM paths $ \path -> do
+    let prefix e = T.pack path <> ": " <> e
+    result <- Yaml.decodeFileEither path
+    pure $ case result of
+      Left err -> [prefix . T.pack $ Yaml.prettyPrintParseException err]
+      Right (frag :: Fragment) -> map prefix $ validateFragment config frag
+  pure $ concat results
+
+-- | Check that every project with files changed since the fork point has at
+-- least one *new* changelog fragment (created in the diff).  Pre-existing
+-- fragments committed before the fork point do not count.
+validateDiff :: Config -> FilePath -> IO [Text]
+validateDiff config baseDir = do
+  forkPoint <- findForkPoint baseDir
+  case forkPoint of
+    Nothing ->
+      pure ["Could not determine fork point - is this branch tracking a remote?"]
+    Just base -> do
+      changed <- changedFiles baseDir base
+      added <- addedFiles baseDir base
+      let changesPrefix = configChangesDir config
+          newFragmentPaths = filter (isNewFragment changesPrefix) added
+      newFragments <- forM newFragmentPaths $ \path -> do
+        let fullPath = baseDir </> path
+        result <- Yaml.decodeFileEither fullPath
+        pure $ case result of
+          Left _ -> Nothing
+          Right (frag :: Fragment) -> Just frag
+      let fragmentProjects =
+            Set.fromList . map fragmentProject $ catMaybes newFragments
+      pure
+        . mapMaybe (checkProject changesPrefix changed fragmentProjects)
+        . Map.toList
+        $ configProjects config
+
+-- | Check a single project: if any of its files were changed, it must have
+-- a fragment.
+checkProject
+  :: FilePath
+  -> [FilePath]
+  -> Set.Set Text
+  -> (Text, ProjectConfig)
+  -> Maybe Text
+checkProject changesPrefix changed fragmentProjects (projectName, projectConfig) =
+  let projectDir = takeDirectory $ projectChangelog projectConfig
+      modified = filter (fileInProject changesPrefix projectDir) changed
+   in if null modified || Set.member projectName fragmentProjects
+        then Nothing
+        else
+          Just
+            $ "Project "
+            <> projectName
+            <> " has modified files but no changelog fragment.\n"
+            <> "  Copy "
+            <> T.pack changesPrefix
+            <> "/_TEMPLATE.yml to "
+            <> T.pack changesPrefix
+            <> "/<your-fragment>.yml and fill it in,\n"
+            <> "  or run: herald new"
+
+-- | Check whether a file belongs to a project directory.
+-- Excludes files in the changes directory (fragments shouldn't trigger
+-- themselves).
+fileInProject :: FilePath -> FilePath -> FilePath -> Bool
+fileInProject changesDir _ file
+  | (changesDir <> "/") `isPrefixOf` file = False
+fileInProject _ "." _ = True
+fileInProject _ projectDir file =
+  (projectDir <> "/") `isPrefixOf` file
+
+-- | Check that new changelog fragments on this branch have the expected PR number.
+-- Finds fragment files added since the fork point and verifies each one's PR field.
+validatePR :: Config -> FilePath -> Int -> IO [Text]
+validatePR config baseDir expectedPR = do
+  forkPoint <- findForkPoint baseDir
+  case forkPoint of
+    Nothing ->
+      pure ["Could not determine fork point - is this branch tracking a remote?"]
+    Just base -> do
+      added <- addedFiles baseDir base
+      let changesPrefix = configChangesDir config
+          newFragments = filter (isNewFragment changesPrefix) added
+      results <- forM newFragments $ \path -> do
+        let fullPath = baseDir </> path
+        result <- Yaml.decodeFileEither fullPath
+        pure $ case result of
+          Left err ->
+            [T.pack path <> ": " <> T.pack (Yaml.prettyPrintParseException err)]
+          Right (frag :: Fragment)
+            | fragmentPR frag /= expectedPR ->
+                [ T.pack path
+                    <> ": PR number "
+                    <> T.pack (show $ fragmentPR frag)
+                    <> " does not match expected "
+                    <> T.pack (show expectedPR)
+                ]
+            | otherwise -> []
+      pure $ concat results
+
+-- | Check whether a path is a new changelog fragment file in the changes
+-- directory.  Template files (starting with @_@) are excluded.
+isNewFragment :: FilePath -> FilePath -> Bool
+isNewFragment prefix path =
+  (prefix <> "/")
+    `isPrefixOf` path
+    && takeExtension path
+    `elem` [".yml", ".yaml"]
+    && not ("_" `isPrefixOf` takeFileName path)

--- a/herald/src/Herald/Config.hs
+++ b/herald/src/Herald/Config.hs
@@ -1,0 +1,19 @@
+module Herald.Config
+  ( loadConfig
+  )
+where
+
+import RIO
+
+import Data.Yaml qualified as Yaml
+
+import Herald.Git (normaliseGitRepo)
+import Herald.Types (Config (..))
+
+-- | Load a herald config from a YAML file.
+-- The @git-repo@ field is normalised so that bare @owner\/repo@ slugs,
+-- SSH URLs, and full HTTPS URLs all produce a usable HTTPS base URL.
+loadConfig :: FilePath -> IO (Either String Config)
+loadConfig path = fmap normalise . first Yaml.prettyPrintParseException <$> Yaml.decodeFileEither path
+ where
+  normalise c = c{configGitRepo = normaliseGitRepo $ configGitRepo c}

--- a/herald/src/Herald/Fragment.hs
+++ b/herald/src/Herald/Fragment.hs
@@ -1,0 +1,28 @@
+module Herald.Fragment
+  ( validateFragment
+  )
+where
+
+import RIO
+
+import Data.Map.Strict qualified as Map
+import Data.Text qualified as T
+
+import Herald.Types (Config (..), Fragment (..))
+
+-- | Validate a fragment against the config.
+-- Returns a list of error messages. Empty list means valid.
+validateFragment :: Config -> Fragment -> [Text]
+validateFragment config frag =
+  concat
+    [ [ "Unknown project: " <> fragmentProject frag
+      | not (Map.member (fragmentProject frag) (configProjects config))
+      ]
+    , ["Kinds list must not be empty" | null (fragmentKinds frag)]
+    , [ "Unknown kind: " <> k
+      | k <- fragmentKinds frag
+      , not (Map.member k (configKinds config))
+      ]
+    , ["Description must not be empty" | T.null . T.strip $ fragmentDescription frag]
+    , ["PR number must be positive" | fragmentPR frag <= 0]
+    ]

--- a/herald/src/Herald/Fragment/Read.hs
+++ b/herald/src/Herald/Fragment/Read.hs
@@ -1,0 +1,58 @@
+-- | Reading changelog fragment files from the changes directory.
+--
+-- Shared by "Herald.Command.Batch", "Herald.Command.Next", and the CLI.
+module Herald.Fragment.Read
+  ( readAllFragments
+  , readProjectFragments
+  , discoverFragmentPaths
+  )
+where
+
+import RIO
+
+import Data.List (sort)
+import Data.Yaml qualified as Yaml
+import System.Directory (doesDirectoryExist, listDirectory)
+import System.FilePath (takeExtension, takeFileName, (</>))
+
+import Herald.Types (Config (..), Fragment (..), throwHerald)
+
+-- | Read all fragment YAML files from the changes directory.
+-- Returns @(filename, fragment)@ pairs where filename is relative to the
+-- changes directory.
+readAllFragments :: Config -> FilePath -> IO [(FilePath, Fragment)]
+readAllFragments config baseDir = do
+  let changesDir = baseDir </> configChangesDir config
+  files <- discoverFragmentFiles changesDir
+  forM files $ \f -> do
+    frag <-
+      either (\err -> throwHerald $ f <> ": " <> Yaml.prettyPrintParseException err) pure
+        =<< Yaml.decodeFileEither (changesDir </> f)
+    pure (f, frag)
+
+-- | Read fragments belonging to a specific project.
+readProjectFragments :: Config -> FilePath -> Text -> IO [(FilePath, Fragment)]
+readProjectFragments config baseDir package =
+  filter (\(_, frag) -> fragmentProject frag == package)
+    <$> readAllFragments config baseDir
+
+-- | List full paths to all @.yml@ fragment files (for validation).
+discoverFragmentPaths :: Config -> FilePath -> IO [FilePath]
+discoverFragmentPaths config baseDir = do
+  let changesDir = baseDir </> configChangesDir config
+  files <- discoverFragmentFiles changesDir
+  pure [changesDir </> f | f <- files]
+
+-- | List @.yml@/@.yaml@ filenames in a directory (relative, sorted).
+-- Files starting with @_@ are skipped (used for templates).
+discoverFragmentFiles :: FilePath -> IO [FilePath]
+discoverFragmentFiles dir = do
+  exists <- doesDirectoryExist dir
+  if exists
+    then sort . filter isFragment <$> listDirectory dir
+    else pure []
+ where
+  isFragment f = takeExtension f `elem` [".yml", ".yaml"] && not (isTemplate f)
+  isTemplate f = case takeFileName f of
+    '_' : _ -> True
+    _ -> False

--- a/herald/src/Herald/Fragment/Render.hs
+++ b/herald/src/Herald/Fragment/Render.hs
@@ -1,0 +1,54 @@
+module Herald.Fragment.Render
+  ( renderSection
+  , isNotable
+  )
+where
+
+import RIO
+
+import Data.List (sortBy)
+import Data.Map.Strict qualified as Map
+import Data.Text qualified as T
+import Data.Time (Day)
+
+import Herald.Pvp (Pvp, showPvp)
+import Herald.Types (Config (..), Fragment (..), KindDef (..))
+
+-- | Render a list of fragments into a markdown changelog section.
+renderSection :: Config -> Pvp -> Day -> [Fragment] -> Text
+renderSection config version day frags =
+  let header = "## " <> T.pack (showPvp version) <> " -- " <> T.pack (show day)
+      notable = filter (isNotable config) frags
+      sorted = sortBy (comparing $ Down . fragmentPR) notable
+      entries = map (renderEntry config) sorted
+   in if null entries
+        then header <> "\n"
+        else T.intercalate "\n" $ header : "" : entries
+
+-- | Check if a fragment has at least one notable kind.
+isNotable :: Config -> Fragment -> Bool
+isNotable config frag =
+  any (\k -> maybe False kindNotable $ Map.lookup k $ configKinds config) $ fragmentKinds frag
+
+renderEntry :: Config -> Fragment -> Text
+renderEntry config frag =
+  T.intercalate
+    "\n"
+    [ "- " <> renderDescription (fragmentDescription frag)
+    , "  (" <> T.intercalate ", " (fragmentKinds frag) <> ")"
+    , "  [PR "
+        <> tshow (fragmentPR frag)
+        <> "]("
+        <> configGitRepo config
+        <> "/pull/"
+        <> tshow (fragmentPR frag)
+        <> ")"
+    , ""
+    ]
+
+renderDescription :: Text -> Text
+renderDescription desc =
+  case T.lines desc of
+    [] -> ""
+    [single] -> single
+    (firstLine : rest) -> T.intercalate "\n" $ firstLine : map ("  " <>) rest

--- a/herald/src/Herald/Git.hs
+++ b/herald/src/Herald/Git.hs
@@ -1,0 +1,227 @@
+-- | High-level git operations for Herald.
+--
+-- Most functions read directly from the @.git\/@ filesystem via
+-- "Herald.Git.Repository".  Diff operations ('findForkPoint', 'changedFiles')
+-- shell out to @git@ since they require commit-graph traversal.
+module Herald.Git
+  ( currentBranch
+  , userNick
+  , detectGitRepo
+  , parseRepoSlug
+  , normaliseGitRepo
+  , defaultRemoteBranch
+  , findForkPoint
+  , changedFiles
+  , addedFiles
+  , gitAdd
+  , gitCommit
+  , gitTag
+  )
+where
+
+import RIO
+
+import Control.Monad.Trans.Maybe (MaybeT (..), runMaybeT)
+import Data.Char (isAlphaNum, isSpace)
+import Data.Text qualified as T
+import System.Directory (doesFileExist)
+import System.Environment (lookupEnv)
+import System.FilePath ((</>))
+import System.Process (readProcessWithExitCode)
+
+import Herald.Git.Repository (GitRepo (..), openRepo, readBranch, readConfigValue)
+import Herald.Types (throwHerald)
+
+-------------------------------------------------------------------------------
+-- Branch
+-------------------------------------------------------------------------------
+
+-- | Get the current git branch name, sanitised for use in filenames.
+-- Returns the part after the last @\/@, with non-alphanumeric chars replaced
+-- by @_@.  Returns empty string if not in a git repo, on a detached HEAD,
+-- or on a well-known default branch.
+currentBranch :: IO String
+currentBranch = do
+  result <- runMaybeT $ do
+    repo <- MaybeT $ openRepo "."
+    name <- MaybeT $ readBranch repo
+    let short = lastSegment '/' name
+    guard $ short `notElem` ["main", "master", "develop", "HEAD"]
+    pure $ sanitise short
+  pure $ fromMaybe "" result
+ where
+  sanitise = map (\c -> if isAlphaNum c || c == '_' then c else '_')
+
+  lastSegment _ [] = ""
+  lastSegment sep s = case break (== sep) s of
+    (part, []) -> part
+    (_, _ : rest) -> lastSegment sep rest
+
+-------------------------------------------------------------------------------
+-- User nick
+-------------------------------------------------------------------------------
+
+-- | Get a user nick for fragment filenames.
+-- Tries (in order): @scriv.user-nick@, @github.user@, email local-part, @$USER@.
+userNick :: IO String
+userNick = do
+  repo <- openRepo "."
+  result <-
+    runMaybeT
+      $ MaybeT (configGet repo "scriv.user-nick")
+      <|> MaybeT (configGet repo "github.user")
+      <|> MaybeT (fmap (takeWhile (/= '@')) <$> configGet repo "user.email")
+      <|> MaybeT (lookupEnv "USER")
+  pure $ fromMaybe "somebody" result
+ where
+  configGet Nothing _ = pure Nothing
+  configGet (Just r) key = readConfigValue r key
+
+-------------------------------------------------------------------------------
+-- Git repo detection
+-------------------------------------------------------------------------------
+
+-- | Try to extract the owner\/repo slug from the origin remote URL.
+-- Returns 'Nothing' when detection fails (no origin remote, unrecognised URL format).
+detectGitRepo :: FilePath -> IO (Maybe Text)
+detectGitRepo baseDir = runMaybeT $ do
+  repo <- MaybeT $ openRepo baseDir
+  url <- T.pack <$> MaybeT (readConfigValue repo "remote.origin.url")
+  MaybeT . pure $ parseRepoSlug url
+
+-- | Parse a git remote URL (SSH or HTTPS) into a full HTTPS base URL
+-- suitable for constructing PR links (e.g. @https:\/\/github.com\/owner\/repo@).
+-- Returns 'Nothing' for unsupported formats or when the result does not
+-- contain at least two non-empty path segments (owner\/repo).
+parseRepoSlug :: Text -> Maybe Text
+parseRepoSlug url
+  | "git@" `T.isPrefixOf` url =
+      -- git@host:owner/repo.git -> https://host/owner/repo
+      do
+        let rest = T.drop (T.length "git@") url
+        -- Require a colon separator (not a slash -- that would be ssh:// style)
+        guard $ T.any (== ':') rest
+        let host = T.takeWhile (/= ':') rest
+            path = T.drop 1 $ T.dropWhile (/= ':') rest
+        guard . not $ T.null host
+        validateSlug host $ stripDotGit path
+  | "https://" `T.isPrefixOf` url =
+      -- https://host/owner/repo.git -> https://host/owner/repo
+      let parts = T.splitOn "/" . T.drop (T.length "https://") $ url
+       in case parts of
+            (host : pathParts)
+              | not (T.null host) ->
+                  validateSlug host . stripDotGit $ T.intercalate "/" pathParts
+            _ -> Nothing
+  | otherwise = Nothing
+ where
+  stripDotGit t = fromMaybe t $ T.stripSuffix ".git" t
+  -- Require at least owner/repo (two non-empty segments)
+  validateSlug host slug = case T.splitOn "/" slug of
+    (owner : repo : _)
+      | not (T.null owner) && not (T.null repo) ->
+          Just $ "https://" <> host <> "/" <> slug
+    _ -> Nothing
+
+-- | Normalise a @git-repo@ config value to a full HTTPS base URL.
+--
+-- Accepts:
+--
+-- * Full HTTPS URL: @https:\/\/github.com\/owner\/repo@ (passed through)
+-- * SSH URL: @git\@host:owner\/repo.git@ (converted via 'parseRepoSlug')
+-- * Bare slug: @owner\/repo@ (assumed GitHub: @https:\/\/github.com\/owner\/repo@)
+--
+-- Returns the original text unchanged if it does not match any known format.
+normaliseGitRepo :: Text -> Text
+normaliseGitRepo t =
+  fromMaybe stripped $ parseRepoSlug stripped <|> bareSlug stripped
+ where
+  stripped = fromMaybe t $ T.stripSuffix "/" t
+  bareSlug s = case T.splitOn "/" s of
+    [owner, repo]
+      | not $ T.null owner
+      , not $ T.null repo
+      , T.all isSlugChar owner
+      , T.all isSlugChar repo ->
+          Just $ "https://github.com/" <> s
+    _ -> Nothing
+  isSlugChar c = isAlphaNum c || c == '-' || c == '_' || c == '.'
+
+-------------------------------------------------------------------------------
+-- Diff operations (require git process)
+-------------------------------------------------------------------------------
+
+-- | Read the default remote branch name from @refs\/remotes\/origin\/HEAD@.
+-- Falls back to @git symbolic-ref@ if the file doesn't exist.
+defaultRemoteBranch :: FilePath -> IO (Maybe String)
+defaultRemoteBranch baseDir = runMaybeT $ tryFilesystem <|> tryGitCommand
+ where
+  tryFilesystem = do
+    repo <- MaybeT $ openRepo baseDir
+    let headRef = gitDir repo </> "refs" </> "remotes" </> "origin" </> "HEAD"
+    guard =<< liftIO (doesFileExist headRef)
+    content <- liftIO $ readFileUtf8 headRef
+    fmap T.unpack
+      . MaybeT
+      . pure
+      . T.stripPrefix "ref: refs/remotes/origin/"
+      $ T.strip content
+
+  tryGitCommand =
+    MaybeT $ gitCommandIn baseDir ["symbolic-ref", "--short", "refs/remotes/origin/HEAD"]
+
+-- | Find the fork point: the merge-base between HEAD and the default remote branch.
+-- Returns the commit hash of the common ancestor.
+findForkPoint :: FilePath -> IO (Maybe String)
+findForkPoint baseDir = runMaybeT $ do
+  branch <- MaybeT $ defaultRemoteBranch baseDir
+  MaybeT $ gitCommandIn baseDir ["merge-base", "HEAD", "origin/" <> branch]
+
+-- | List files changed between a commit and HEAD.
+changedFiles :: FilePath -> String -> IO [FilePath]
+changedFiles baseDir base = do
+  result <- gitCommandIn baseDir ["diff", "--name-only", base <> "..HEAD"]
+  pure . maybe [] (filter (not . null) . lines) $ result
+
+-- | List files *added* (not modified) between a commit and HEAD.
+addedFiles :: FilePath -> String -> IO [FilePath]
+addedFiles baseDir base = do
+  result <- gitCommandIn baseDir ["diff", "--diff-filter=A", "--name-only", base <> "..HEAD"]
+  pure . maybe [] (filter (not . null) . lines) $ result
+
+-------------------------------------------------------------------------------
+-- Staging, committing, tagging
+-------------------------------------------------------------------------------
+
+-- | Stage a list of files (paths relative to the repo root).
+gitAdd :: FilePath -> [FilePath] -> IO ()
+gitAdd _ [] = pure ()
+gitAdd baseDir paths = gitCommandOrFail baseDir $ ["add", "--"] <> paths
+
+-- | Create a commit with the given message. Only staged changes are committed.
+-- Uses @--no-verify@ to skip pre-commit hooks and @--no-gpg-sign@ to avoid
+-- GPG signing issues, since this is an automated release commit.
+gitCommit :: FilePath -> String -> IO ()
+gitCommit baseDir msg = gitCommandOrFail baseDir ["commit", "--no-verify", "--no-gpg-sign", "-m", msg]
+
+-- | Create a lightweight tag at HEAD.
+gitTag :: FilePath -> String -> IO ()
+gitTag baseDir tag = gitCommandOrFail baseDir ["tag", tag]
+
+-- | Run a git command in a directory, throwing on failure.
+gitCommandOrFail :: FilePath -> [String] -> IO ()
+gitCommandOrFail dir args = do
+  (code, _, err) <- readProcessWithExitCode "git" (["-C", dir] <> args) ""
+  case code of
+    ExitSuccess -> pure ()
+    _ -> throwHerald $ "git " <> unwords args <> " failed: " <> err
+
+-- | Run a git command in a given directory and return trimmed stdout on success.
+gitCommandIn :: FilePath -> [String] -> IO (Maybe String)
+gitCommandIn dir args = do
+  (code, out, _) <- readProcessWithExitCode "git" (["-C", dir] <> args) ""
+  pure $ case code of
+    ExitSuccess -> Just $ trimEnd out
+    _ -> Nothing
+ where
+  trimEnd = reverse . dropWhile isSpace . reverse

--- a/herald/src/Herald/Git/Repository.hs
+++ b/herald/src/Herald/Git/Repository.hs
@@ -1,0 +1,148 @@
+-- | Low-level git repository reading from the filesystem.
+--
+-- Replaces all @System.Process@ \"git\" invocations with direct reads of
+-- the @.git\/@ directory structure (HEAD, refs\/tags, packed-refs, config).
+module Herald.Git.Repository
+  ( GitRepo (..)
+  , openRepo
+  , readBranch
+  , readConfigValue
+
+    -- * Exported for testing
+  , lookupGitConfig
+  )
+where
+
+import RIO
+
+import Control.Monad.Trans.Maybe (MaybeT (..), runMaybeT)
+import Data.Text qualified as T
+import System.Directory (doesDirectoryExist, doesFileExist, makeAbsolute)
+import System.FilePath (isAbsolute, takeDirectory, (</>))
+
+-- | An opened git repository, identified by its @.git@ directory path.
+newtype GitRepo = GitRepo {gitDir :: FilePath}
+  deriving Show
+
+-------------------------------------------------------------------------------
+-- Opening a repository
+-------------------------------------------------------------------------------
+
+-- | Discover the git directory starting from @startDir@, walking up parents.
+-- Handles both regular repos (@.git/@ directory) and worktrees\/submodules
+-- (@.git@ file containing @gitdir: path@).
+openRepo :: FilePath -> IO (Maybe GitRepo)
+openRepo startDir = makeAbsolute startDir >>= runMaybeT . walk
+ where
+  walk dir =
+    let gitPath = dir </> ".git"
+     in tryDirectory gitPath <|> tryGitFile gitPath dir <|> walkUp dir
+
+  walkUp dir = do
+    let parent = takeDirectory dir
+    guard $ parent /= dir -- stop at filesystem root
+    walk parent
+
+  tryDirectory gitPath = do
+    guard =<< lift (doesDirectoryExist gitPath)
+    pure $ GitRepo gitPath
+
+  tryGitFile gitPath baseDir = do
+    guard =<< lift (doesFileExist gitPath)
+    content <- lift $ readFileUtf8 gitPath
+    target <- MaybeT . pure . T.stripPrefix "gitdir:" $ T.strip content
+    let targetPath = T.unpack $ T.strip target
+    pure
+      . GitRepo
+      $ if isAbsolute targetPath
+        then targetPath
+        else baseDir </> targetPath
+
+-------------------------------------------------------------------------------
+-- Reading HEAD
+-------------------------------------------------------------------------------
+
+-- | Read the current branch name from @HEAD@.
+-- Returns 'Nothing' on detached HEAD or missing file.
+readBranch :: GitRepo -> IO (Maybe String)
+readBranch (GitRepo gd) = runMaybeT $ do
+  let headFile = gd </> "HEAD"
+  guard =<< lift (doesFileExist headFile)
+  content <- lift $ readFileUtf8 headFile
+  fmap T.unpack
+    . MaybeT
+    . pure
+    $ T.stripPrefix "ref: refs/heads/"
+    $ T.strip content
+
+-------------------------------------------------------------------------------
+-- Reading git config
+-------------------------------------------------------------------------------
+
+-- | Read a single value from the repo's @.git\/config@.
+--
+-- Key format follows git conventions:
+--
+--   * @\"section.variable\"@   -- looks for @[section]@ then @variable@
+--   * @\"section.sub.variable\"@ -- looks for @[section \"sub\"]@ then @variable@
+readConfigValue :: GitRepo -> String -> IO (Maybe String)
+readConfigValue (GitRepo gd) key = runMaybeT $ do
+  let configFile = gd </> "config"
+  guard =<< lift (doesFileExist configFile)
+  content <- lift $ readFileUtf8 configFile
+  fmap T.unpack . MaybeT . pure $ lookupGitConfig (T.pack key) content
+
+-- | Pure lookup in git-config text.  Exported for testing.
+lookupGitConfig :: Text -> Text -> Maybe Text
+lookupGitConfig key content = go Nothing . map (T.filter (/= '\r')) $ T.lines content
+ where
+  (targetSection, targetSubsection, targetKey) = splitConfigKey key
+
+  go _ [] = Nothing
+  go currentSection (line : rest) =
+    case parseSectionHeader $ T.strip line of
+      Just section -> go (Just section) rest
+      Nothing
+        | Just (k, v) <- parseKeyValue $ T.strip line
+        , Just (sec, sub) <- currentSection
+        , T.toLower sec == targetSection
+        , sub == targetSubsection
+        , T.toLower (T.strip k) == targetKey ->
+            Just $ T.strip v
+        | otherwise ->
+            go currentSection rest
+
+-- | Parse @section.key@ or @section.subsection.key@ into components.
+-- Section and key are lowered; subsection is case-sensitive (per git spec).
+splitConfigKey :: Text -> (Text, Maybe Text, Text)
+splitConfigKey key = (T.toLower section, subsection, T.toLower variable)
+ where
+  (section, rest) = T.break (== '.') key
+  afterDot = T.drop 1 rest
+  (subsection, variable) = case T.breakOnEnd "." afterDot of
+    ("", var) -> (Nothing, var)
+    (subDot, var) -> (Just $ T.dropEnd 1 subDot, var)
+
+-- | Parse a @[section]@ or @[section \"subsection\"]@ header.
+parseSectionHeader :: Text -> Maybe (Text, Maybe Text)
+parseSectionHeader line = do
+  rest1 <- T.stripPrefix "[" line
+  inner <- T.stripSuffix "]" rest1
+  let trimmed = T.strip inner
+  pure $ case T.breakOn " \"" trimmed of
+    (name, quoted)
+      | T.null quoted -> (T.strip name, Nothing)
+      | otherwise ->
+          let subsection = T.dropEnd 1 $ T.drop 2 quoted -- drop leading  \" and trailing \"
+           in (T.strip name, Just subsection)
+
+-- | Parse a @key = value@ line, skipping comments and blanks.
+parseKeyValue :: Text -> Maybe (Text, Text)
+parseKeyValue line
+  | T.null line = Nothing
+  | T.isPrefixOf "#" line = Nothing
+  | T.isPrefixOf ";" line = Nothing
+  | T.isInfixOf "=" line =
+      let (k, rest) = T.breakOn "=" line
+       in Just (T.strip k, T.strip $ T.drop 1 rest)
+  | otherwise = Nothing

--- a/herald/src/Herald/Pvp.hs
+++ b/herald/src/Herald/Pvp.hs
@@ -1,0 +1,63 @@
+module Herald.Pvp
+  ( Pvp (..)
+  , BumpLevel
+  , parsePvp
+  , showPvp
+  , bumpPvp
+  )
+where
+
+import RIO
+
+import Data.Char (isDigit)
+import Data.List (intercalate)
+import Data.List.NonEmpty (nonEmpty)
+
+-- | A PVP version with one or more dot-separated non-negative integer components.
+newtype Pvp = Pvp
+  { pvpComponents :: NonEmpty Int
+  }
+  deriving (Eq, Ord, Show)
+
+-- | PVP bump expressed as a version delta.
+-- The leftmost non-zero component indicates which position to bump.
+-- e.g. Pvp (0 :| [1, 0, 0]) means bump the 2nd digit and zero everything to its right.
+type BumpLevel = Pvp
+
+parsePvp :: String -> Maybe Pvp
+parsePvp [] = Nothing
+parsePvp s = do
+  parts <- traverse parseComponent $ splitOnDot s
+  ne <- nonEmpty parts
+  pure $ Pvp ne
+ where
+  splitOnDot str = case break (== '.') str of
+    (part, []) -> [part]
+    (part, _ : rest) -> part : splitOnDot rest
+  parseComponent [] = Nothing
+  parseComponent cs
+    | all isDigit cs = readMaybe cs
+    | otherwise = Nothing
+
+showPvp :: Pvp -> String
+showPvp (Pvp cs) = intercalate "." . fmap show $ toList cs
+
+-- | Bump a version by applying a bump level.
+-- Finds the leftmost non-zero component in the bump level,
+-- increments that component in the version, and zeros everything to its right.
+-- If the version has fewer components than the bump position, it is extended with zeros.
+-- If the bump level is all zeros, returns the version unchanged.
+bumpPvp :: BumpLevel -> Pvp -> Pvp
+bumpPvp (Pvp bumpCs) (Pvp verCs) =
+  case findBumpIndex 0 $ toList bumpCs of
+    Nothing -> Pvp verCs -- all-zero bump level: identity
+    Just idx ->
+      let verList = toList verCs
+          padded = verList ++ replicate (max 0 $ idx + 1 - length verList) 0
+          bumped = zipWith (\i v -> if i == idx then v + 1 else if i > idx then 0 else v) [0 ..] padded
+       in Pvp . fromMaybe verCs $ nonEmpty bumped
+ where
+  findBumpIndex _ [] = Nothing
+  findBumpIndex i (c : cs)
+    | c /= 0 = Just i
+    | otherwise = findBumpIndex (i + 1) cs

--- a/herald/src/Herald/Terminal.hs
+++ b/herald/src/Herald/Terminal.hs
@@ -1,0 +1,251 @@
+-- | Interactive terminal prompts for Herald.
+--
+-- Provides multi-select menus (with j\/k navigation), multi-line input,
+-- and integer input.  Falls back to plain numbered-list input when stdout
+-- is not a terminal (e.g.\ piped or in CI).
+module Herald.Terminal
+  ( promptMultiSelect
+  , promptMultiLine
+  , promptInt
+  , stripAnsi
+  )
+where
+
+import RIO
+
+import Data.Char (isSpace)
+import Data.List (zip3)
+import Data.Text qualified as T
+import System.Console.Haskeline (defaultSettings, getInputLine, runInputT)
+import System.Directory (getTemporaryDirectory, removeFile)
+import System.Environment (lookupEnv)
+import System.IO qualified as IO
+import System.Process (callCommand)
+
+import Herald.Types (throwHerald)
+
+-------------------------------------------------------------------------------
+-- Multi-select prompt
+-------------------------------------------------------------------------------
+
+-- | Prompt the user to select one or more items from a navigable list.
+--
+-- In a terminal: j\/k or arrows to move, space to toggle, enter to confirm.
+-- Non-terminal: falls back to comma-separated number input.
+promptMultiSelect :: String -> [a] -> (a -> String) -> IO [a]
+promptMultiSelect label items formatItem = do
+  when (null items)
+    $ throwHerald
+    $ "No "
+    <> label
+    <> "s configured"
+  isTerm <- IO.hIsTerminalDevice IO.stdout
+  if isTerm then interactiveSelect else fallbackSelect isTerm
+ where
+  fallbackSelect isTerm = do
+    putPrompt isTerm $ "Choose " <> label <> "(s) (comma-separated numbers):"
+    forM_ (zip [1 :: Int ..] items) $ \(i, item) ->
+      IO.putStrLn $ "  " <> colorise isTerm "36" (show i <> ".") <> " " <> formatItem item
+    IO.putStr $ colorise isTerm "36" "> "
+    IO.hFlush IO.stdout
+    input <- IO.getLine
+    case parseSelection items input of
+      Just selected | not (null selected) -> pure selected
+      _ -> fallbackSelect isTerm
+
+  interactiveSelect = do
+    putPrompt True $ "Choose " <> label <> "(s)  [j/k or arrows move, space toggle, enter confirm]"
+    let initSelected = replicate (length items) False
+    IO.hSetBuffering IO.stdin IO.NoBuffering
+    IO.hSetEcho IO.stdin False
+    result <-
+      menuLoop True 0 initSelected `finally` do
+        IO.hSetBuffering IO.stdin IO.LineBuffering
+        IO.hSetEcho IO.stdin True
+    let selected = [item | (item, sel) <- zip items result, sel]
+    if null selected
+      then do
+        IO.putStrLn $ colorise True "31" "  No selection. Try again."
+        interactiveSelect
+      else pure selected
+
+  menuLoop firstRender cursor selected = do
+    renderMenu firstRender cursor selected
+    key <- readKey
+    let n = length items
+    case key of
+      KeyUp -> menuLoop False (max 0 (cursor - 1)) selected
+      KeyDown -> menuLoop False (min (n - 1) (cursor + 1)) selected
+      KeyToggle ->
+        let toggled = zipWith (\i s -> if i == cursor then not s else s) [0 :: Int ..] selected
+         in menuLoop False cursor toggled
+      KeyConfirm -> do
+        clearLines (length items)
+        pure selected
+      KeyOther -> menuLoop False cursor selected
+
+  renderMenu firstRender cursor selected = do
+    unless firstRender $ clearLines (length items)
+    forM_ (zip3 [0 :: Int ..] items selected) $ \(i, item, sel) ->
+      let pointer = if i == cursor then colorise True "36" "> " else "  "
+          check = if sel then colorise True "32" "[x] " else "[ ] "
+       in IO.putStrLn $ pointer <> check <> formatItem item
+    IO.hFlush IO.stdout
+
+-------------------------------------------------------------------------------
+-- Multi-line prompt
+-------------------------------------------------------------------------------
+
+-- | Prompt for multiline text.
+--
+-- When @$VISUAL@ or @$EDITOR@ is set, opens the editor for full multi-line
+-- editing (arrow keys, undo, etc.).  Otherwise falls back to haskeline
+-- line-by-line input (empty line finishes).
+promptMultiLine :: String -> IO Text
+promptMultiLine label = go
+ where
+  go = do
+    isTerm <- IO.hIsTerminalDevice IO.stdout
+    result <-
+      if isTerm then terminalInput else plainInput isTerm
+    if T.null result
+      then do
+        IO.putStrLn $ colorise isTerm "31" "Cannot be empty, try again."
+        go
+      else pure result
+
+  terminalInput = do
+    visual <- lookupEnv "VISUAL"
+    editor <- lookupEnv "EDITOR"
+    maybe haskelineInput editorInput $ visual <|> editor
+
+  editorInput editor = do
+    putPrompt True $ label <> ":"
+    IO.putStrLn $ colorise True "36" "  (opening " <> editor <> ")"
+    tmpDir <- getTemporaryDirectory
+    (path, tmpHandle) <- IO.openTempFile tmpDir "herald-description.txt"
+    IO.hClose tmpHandle
+    flip finally (removeFile path) $ do
+      callCommand $ editor <> " " <> shellQuote path
+      T.strip <$> readFileUtf8 path
+
+  haskelineInput = do
+    putPrompt True $ label <> " (empty line to finish):"
+    lineTexts <- runInputT defaultSettings collect
+    pure . T.strip $ T.intercalate "\n" lineTexts
+   where
+    collect = do
+      mLine <- getInputLine "| "
+      case mLine of
+        Nothing -> pure []
+        Just line
+          | all isSpace line -> pure []
+          | otherwise -> (T.pack line :) <$> collect
+
+  plainInput isTerm = do
+    putPrompt isTerm $ label <> " (empty line to finish):"
+    lineTexts <- collectLinesPlain isTerm
+    pure . T.strip $ T.intercalate "\n" lineTexts
+
+  collectLinesPlain isTerm = do
+    IO.putStr $ colorise isTerm "36" "| "
+    IO.hFlush IO.stdout
+    line <- stripAnsi . T.pack <$> IO.getLine
+    if T.null $ T.strip line
+      then pure []
+      else (line :) <$> collectLinesPlain isTerm
+
+-------------------------------------------------------------------------------
+-- Integer prompt
+-------------------------------------------------------------------------------
+
+-- | Prompt for a positive integer.
+-- Uses haskeline for line editing when in a terminal.
+promptInt :: String -> IO Int
+promptInt label = go
+ where
+  go = do
+    isTerm <- IO.hIsTerminalDevice IO.stdout
+    putPrompt isTerm $ label <> ":"
+    input <-
+      if isTerm
+        then runInputT defaultSettings (getInputLine "> ") >>= maybe (pure "") pure
+        else do
+          IO.putStr $ colorise isTerm "36" "> "
+          IO.hFlush IO.stdout
+          IO.getLine
+    case readMaybe input of
+      Just n | n > 0 -> pure n
+      _ -> do
+        IO.putStrLn $ colorise isTerm "31" "Enter a positive integer."
+        go
+
+-------------------------------------------------------------------------------
+-- Internals
+-------------------------------------------------------------------------------
+
+data MenuKey = KeyUp | KeyDown | KeyToggle | KeyConfirm | KeyOther
+
+readKey :: IO MenuKey
+readKey = do
+  c <- IO.getChar
+  case c of
+    'k' -> pure KeyUp
+    'j' -> pure KeyDown
+    ' ' -> pure KeyToggle
+    '\n' -> pure KeyConfirm
+    '\r' -> pure KeyConfirm
+    '\ESC' -> do
+      c2 <- IO.getChar
+      case c2 of
+        '[' -> do
+          c3 <- IO.getChar
+          pure $ case c3 of
+            'A' -> KeyUp
+            'B' -> KeyDown
+            _ -> KeyOther
+        _ -> pure KeyOther
+    _ -> pure KeyOther
+
+clearLines :: Int -> IO ()
+clearLines n = when (n > 0) $ do
+  IO.putStr $ "\ESC[" <> show n <> "A"
+  IO.putStr "\ESC[J"
+
+putPrompt :: Bool -> String -> IO ()
+putPrompt isTerm msg =
+  IO.putStrLn $ colorise isTerm "1;32" "? " <> msg
+
+colorise :: Bool -> String -> String -> String
+colorise False _ s = s
+colorise True code s = "\ESC[" <> code <> "m" <> s <> "\ESC[0m"
+
+parseSelection :: [a] -> String -> Maybe [a]
+parseSelection items input = do
+  let parts = map (T.strip . T.pack) $ splitOn ',' input
+      indexed = zip [1 :: Int ..] items
+  indices <- traverse (readMaybe . T.unpack) parts
+  traverse (`lookup` indexed) indices
+
+splitOn :: Char -> String -> [String]
+splitOn _ [] = []
+splitOn delim s = case break (== delim) s of
+  (part, []) -> [part]
+  (part, _ : rest) -> part : splitOn delim rest
+
+-- | Shell-quote a string by wrapping in single quotes and escaping embedded
+-- single quotes.  e.g. @"it's"@ becomes @"'it'\\''s'"@.
+shellQuote :: String -> String
+shellQuote s = "'" <> concatMap (\c -> if c == '\'' then "'\\''" else [c]) s <> "'"
+
+-- | Strip ANSI escape sequences from text (e.g. arrow key artifacts).
+stripAnsi :: Text -> Text
+stripAnsi = go
+ where
+  go t = case T.breakOn "\ESC[" t of
+    (before, rest)
+      | T.null rest -> before
+      | otherwise ->
+          let afterEsc = T.drop 2 rest -- drop \ESC[
+              afterSeq = T.dropWhile (\c -> c >= '0' && c <= '?' || c == ';') afterEsc
+           in before <> go (T.drop 1 afterSeq) -- drop the final letter

--- a/herald/src/Herald/Types.hs
+++ b/herald/src/Herald/Types.hs
@@ -1,0 +1,147 @@
+module Herald.Types
+  ( KindDef (..)
+  , Fragment (..)
+  , ProjectConfig (..)
+  , Config (..)
+  , HeraldException (..)
+  , throwHerald
+  , defaultKinds
+  )
+where
+
+import RIO
+
+import Data.Aeson (FromJSON (..), ToJSON (..), object, withObject, (.:), (.:?), (.=))
+import Data.Map.Strict qualified as Map
+
+import Herald.Pvp (BumpLevel, Pvp (..), parsePvp, showPvp)
+
+-- | User-facing error with a clean message (no backtrace noise).
+newtype HeraldException = HeraldException String
+
+instance Show HeraldException where
+  show (HeraldException msg) = msg
+
+instance Exception HeraldException where
+  displayException (HeraldException msg) = msg
+
+-- | Throw a user-facing error with a clean message.
+throwHerald :: MonadIO m => String -> m a
+throwHerald = throwIO . HeraldException
+
+data KindDef = KindDef
+  { kindNotable :: !Bool
+  , kindBump :: !BumpLevel
+  , kindDescription :: !(Maybe Text)
+  }
+  deriving (Eq, Show)
+
+instance FromJSON KindDef where
+  parseJSON = withObject "KindDef" $ \o -> do
+    notable <- fromMaybe True <$> o .:? "notable"
+    bumpStr <- o .: "bump"
+    pvp <- maybe (fail $ "Invalid PVP version in bump: " <> bumpStr) pure $ parsePvp bumpStr
+    desc <- o .:? "description"
+    pure $ KindDef notable pvp desc
+
+instance ToJSON KindDef where
+  toJSON kd =
+    object
+      $ ["notable" .= kindNotable kd | not $ kindNotable kd]
+      <> ["bump" .= showPvp (kindBump kd)]
+      <> maybe [] (\d -> ["description" .= d]) (kindDescription kd)
+
+data Fragment = Fragment
+  { fragmentProject :: !Text
+  , fragmentKinds :: ![Text]
+  , fragmentDescription :: !Text
+  , fragmentPR :: !Int
+  }
+  deriving (Eq, Show)
+
+instance FromJSON Fragment where
+  parseJSON = withObject "Fragment" $ \o ->
+    Fragment
+      <$> o
+      .: "project"
+      <*> o
+      .: "kind"
+      <*> o
+      .: "description"
+      <*> o
+      .: "pr"
+
+instance ToJSON Fragment where
+  toJSON f =
+    object
+      [ "project" .= fragmentProject f
+      , "kind" .= fragmentKinds f
+      , "description" .= fragmentDescription f
+      , "pr" .= fragmentPR f
+      ]
+
+data ProjectConfig = ProjectConfig
+  { projectChangelog :: !FilePath
+  , projectCabalFile :: !(Maybe FilePath)
+  }
+  deriving (Eq, Show)
+
+instance FromJSON ProjectConfig where
+  parseJSON = withObject "ProjectConfig" $ \o ->
+    ProjectConfig
+      <$> o
+      .: "changelog"
+      <*> o
+      .:? "cabal-file"
+
+instance ToJSON ProjectConfig where
+  toJSON pc =
+    object
+      $ [ "changelog" .= projectChangelog pc
+        ]
+      <> maybe [] (\cf -> ["cabal-file" .= cf]) (projectCabalFile pc)
+
+data Config = Config
+  { configGitRepo :: !Text
+  , configChangesDir :: !FilePath
+  , configKinds :: !(Map Text KindDef)
+  , configProjects :: !(Map Text ProjectConfig)
+  }
+  deriving (Eq, Show)
+
+instance FromJSON Config where
+  parseJSON = withObject "Config" $ \o ->
+    Config
+      <$> o
+      .: "git-repo"
+      <*> o
+      .: "changes-dir"
+      <*> o
+      .: "kinds"
+      <*> o
+      .: "projects"
+
+instance ToJSON Config where
+  toJSON c =
+    object
+      [ "git-repo" .= configGitRepo c
+      , "changes-dir" .= configChangesDir c
+      , "kinds" .= configKinds c
+      , "projects" .= configProjects c
+      ]
+
+-- | Default kinds shipped with every new herald config.
+defaultKinds :: Map Text KindDef
+defaultKinds =
+  Map.fromList
+    [ ("breaking", KindDef True (Pvp (0 :| [1, 0, 0])) (Just "the API has changed in a breaking way"))
+    , ("feature", KindDef True (Pvp (0 :| [0, 1, 0])) (Just "introduces a new feature"))
+    , ("compatible", KindDef True (Pvp (0 :| [0, 1, 0])) (Just "the API has changed but is non-breaking"))
+    , ("bugfix", KindDef True (Pvp (0 :| [0, 0, 1])) (Just "fixes a defect"))
+    , ("optimisation", KindDef True (Pvp (0 :| [0, 0, 1])) (Just "measurable performance improvements"))
+    , ("refactoring", KindDef False (Pvp (0 :| [0, 0, 1])) (Just "code quality improvements"))
+    , ("test", KindDef False (Pvp (0 :| [0, 0, 1])) (Just "fixes or modifies tests"))
+    , ("maintenance", KindDef False (Pvp (0 :| [0, 0, 1])) (Just "not directly related to the code"))
+    , ("release", KindDef False (Pvp (0 :| [0, 0, 1])) (Just "related to a new release preparation"))
+    , ("documentation", KindDef False (Pvp (0 :| [0, 0, 1])) (Just "change in code docs, haddocks"))
+    ]

--- a/herald/test-e2e/Main.hs
+++ b/herald/test-e2e/Main.hs
@@ -1,0 +1,20 @@
+module Main where
+
+import Test.Herald.E2E.Batch qualified as Batch
+import Test.Herald.E2E.Fragment qualified as Fragment
+import Test.Herald.E2E.Init qualified as Init
+import Test.Herald.E2E.Next qualified as Next
+import Test.Herald.E2E.Validate qualified as Validate
+import Test.Tasty (defaultMain, testGroup)
+
+main :: IO ()
+main =
+  defaultMain $
+    testGroup
+      "herald-e2e"
+      [ Batch.tests
+      , Validate.tests
+      , Init.tests
+      , Fragment.tests
+      , Next.tests
+      ]

--- a/herald/test-e2e/Test/Herald/E2E/Batch.hs
+++ b/herald/test-e2e/Test/Herald/E2E/Batch.hs
@@ -1,0 +1,468 @@
+module Test.Herald.E2E.Batch (tests) where
+
+import Control.Exception (SomeException, catch)
+import Data.List (sort)
+import Data.Map.Strict qualified as Map
+import Data.Maybe (isJust, isNothing)
+import Data.Text qualified as T
+import Data.Text.IO qualified as T
+import Data.Time (fromGregorian)
+import Data.Yaml qualified as Yaml
+import System.Directory (createDirectoryIfMissing, listDirectory)
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
+import System.Process (readProcessWithExitCode)
+
+import Hedgehog (Property, (===))
+import Hedgehog qualified as H
+import Hedgehog.Extras qualified as H
+import Test.Herald.Assertions (shouldContain)
+import Test.Herald.E2E.Fixtures (setupBatchRepo, setupTestRepo)
+import Test.Herald.Fixtures (pvp, testConfigMultiProject, testDay)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Hedgehog (testProperty)
+
+import Herald.Command.Batch (BatchResult (..), CommitMode (..), batchPackage, commitBatchResult)
+import Herald.Types (Config (..), Fragment (..), HeraldException (..), ProjectConfig (..))
+
+tests :: TestTree
+tests =
+  testGroup
+    "Batch"
+    [ testProperty "batch with explicit version" prop_batch_explicit_version
+    , testProperty "batch with auto-version" prop_batch_auto_version
+    , testProperty "batch updates changelog" prop_batch_updates_changelog
+    , testProperty "full lifecycle output format" prop_full_lifecycle
+    , testProperty "non-notable filtering" prop_non_notable_filtering
+    , testProperty "batch result contains expected fields" prop_batch_result_fields
+    , testProperty "batch with explicit date uses provided date" prop_batch_explicit_date
+    , testProperty "batch --commit creates a commit with batch changes" prop_batch_commit
+    , testProperty "batch --commit-tag creates a commit and a tag" prop_batch_commit_tag
+    , testProperty "batch with no fragments returns Nothing" prop_batch_no_fragments
+    , testProperty "batch same project twice returns Nothing on second call" prop_batch_twice
+    , testProperty "batch version downgrade is rejected" prop_batch_downgrade
+    , testProperty "batch again with new fragments produces second section" prop_batch_idempotent
+    , testProperty "batch without .cabal file uses explicit version" prop_batch_no_cabal
+    , testProperty "batch rejects invalid fragment (unknown kind)" prop_batch_invalid_fragment
+    , testProperty "auto-version without cabal-file is rejected" prop_batch_auto_no_cabal
+    , testProperty "auto-version with missing version: line is rejected" prop_batch_auto_missing_version
+    , testProperty "explicit version equal to current is accepted" prop_batch_same_version
+    , testProperty "unknown project is rejected" prop_batch_unknown_project
+    , testProperty
+        "downgrade check skipped when version: line is missing"
+        prop_batch_downgrade_skipped_missing_version
+    , testProperty
+        "valid kind does not mask invalid kind in same fragment"
+        prop_batch_mixed_valid_invalid_kinds
+    , testProperty "missing CHANGELOG.md on disk is a hard error" prop_batch_missing_changelog
+    , testProperty "missing .cabal file on disk is a hard error" prop_batch_missing_cabal_file
+    ]
+
+-- | Explicit version (9.0.0.0) updates .cabal and changelog; only other-project fragments remain.
+prop_batch_explicit_version :: Property
+prop_batch_explicit_version = H.propertyOnce $ do
+  (cabal, changelog, remaining) <- H.evalIO $ setupTestRepo $ \tmpDir -> do
+    Just _ <- batchPackage testConfigMultiProject tmpDir "cardano-api" (Just $ pvp 9 0 0 0) testDay
+    cabal <- T.readFile $ tmpDir </> "cardano-api" </> "cardano-api.cabal"
+    changelog <- T.readFile $ tmpDir </> "cardano-api" </> "CHANGELOG.md"
+    remaining <- sort <$> listDirectory (tmpDir </> ".changes")
+    pure (cabal, changelog, remaining)
+
+  cabal `shouldContain` "version: 9.0.0.0"
+  changelog `shouldContain` "## 9.0.0.0"
+  remaining === ["50-gen-helpers.yml"]
+
+-- | Auto-version: bugfix (patch) + breaking -> max is breaking -> 8.4.1.2 becomes 8.5.0.0.
+prop_batch_auto_version :: Property
+prop_batch_auto_version = H.propertyOnce $ do
+  (cabal, changelog) <- H.evalIO $ setupTestRepo $ \tmpDir -> do
+    Just _ <- batchPackage testConfigMultiProject tmpDir "cardano-api" Nothing testDay
+    cabal <- T.readFile $ tmpDir </> "cardano-api" </> "cardano-api.cabal"
+    changelog <- T.readFile $ tmpDir </> "cardano-api" </> "CHANGELOG.md"
+    pure (cabal, changelog)
+
+  cabal `shouldContain` "version: 8.5.0.0"
+  changelog `shouldContain` "## 8.5.0.0"
+
+-- | New changelog section is prepended above the existing one; old content preserved.
+prop_batch_updates_changelog :: Property
+prop_batch_updates_changelog = H.propertyOnce $ do
+  changelog <- H.evalIO $ setupTestRepo $ \tmpDir -> do
+    Just _ <- batchPackage testConfigMultiProject tmpDir "cardano-api" Nothing testDay
+    T.readFile $ tmpDir </> "cardano-api" </> "CHANGELOG.md"
+
+  let idxNew = T.length . fst $ T.breakOn "## 8.5.0.0" changelog
+      idxOld = T.length . fst $ T.breakOn "## 8.4.1.2" changelog
+  H.annotate $ "New section at offset " <> show idxNew <> ", old at " <> show idxOld
+  H.assert $ idxNew < idxOld
+  changelog `shouldContain` "Previous change"
+
+-- | Full lifecycle: rendered changelog matches the expected format (R10).
+prop_full_lifecycle :: Property
+prop_full_lifecycle = H.propertyOnce $ do
+  changelog <- H.evalIO $ setupTestRepo $ \tmpDir -> do
+    Just _ <- batchPackage testConfigMultiProject tmpDir "cardano-api" Nothing testDay
+    T.readFile $ tmpDir </> "cardano-api" </> "CHANGELOG.md"
+
+  changelog `shouldContain` "## 8.5.0.0"
+  changelog `shouldContain` "2026-03-25"
+
+  -- Entries sorted by PR number descending: 99 before 42
+  let idx42 = T.length . fst $ T.breakOn "PR 42" changelog
+      idx99 = T.length . fst $ T.breakOn "PR 99" changelog
+  H.assert $ idx99 < idx42
+
+  changelog `shouldContain` "Fix serialization of Conway certificates"
+  changelog `shouldContain` "(bugfix)"
+  changelog `shouldContain` "[PR 42](https://github.com/IntersectMBO/cardano-api/pull/42)"
+
+  changelog `shouldContain` "Add Conway era support"
+  changelog `shouldContain` "(breaking, feature)"
+  changelog `shouldContain` "[PR 99](https://github.com/IntersectMBO/cardano-api/pull/99)"
+
+  changelog `shouldContain` "## 8.4.1.2"
+
+-- | Non-notable fragments (test kind only) contribute to version bump but are hidden from changelog.
+prop_non_notable_filtering :: Property
+prop_non_notable_filtering = H.propertyOnce $ do
+  changelog <- H.evalIO $ setupTestRepo $ \tmpDir -> do
+    Just _ <- batchPackage testConfigMultiProject tmpDir "cardano-api-gen" Nothing testDay
+    T.readFile $ tmpDir </> "cardano-api-gen" </> "CHANGELOG.md"
+
+  changelog `shouldContain` "## 1.0.0.1"
+  H.annotate "Changelog should not contain non-notable entry text"
+  H.assert . not $ T.isInfixOf "Add generator helpers" changelog
+
+-- | BatchResult contains the computed version, consumed fragment names, and file paths.
+prop_batch_result_fields :: Property
+prop_batch_result_fields = H.propertyOnce $ do
+  result <- H.evalIO $ setupTestRepo $ \tmpDir -> do
+    Just r <- batchPackage testConfigMultiProject tmpDir "cardano-api" Nothing testDay
+    pure r
+
+  batchResultVersion result === pvp 8 5 0 0
+  sort (batchResultFragments result) === ["42-fix-serialization.yml", "99-add-conway-support.yml"]
+  H.assert $ T.isSuffixOf "CHANGELOG.md" . T.pack $ batchResultChangelog result
+  H.assert $ maybe False (T.isSuffixOf ".cabal" . T.pack) $ batchResultCabalFile result
+
+-- | An explicit date appears in the changelog header instead of today's date.
+prop_batch_explicit_date :: Property
+prop_batch_explicit_date = H.propertyOnce $ do
+  changelog <- H.evalIO $ setupTestRepo $ \tmpDir -> do
+    let customDay = fromGregorian 2025 12 31
+    Just _ <- batchPackage testConfigMultiProject tmpDir "cardano-api" Nothing customDay
+    T.readFile $ tmpDir </> "cardano-api" </> "CHANGELOG.md"
+
+  changelog `shouldContain` "2025-12-31"
+
+-- | --commit creates a git commit containing exactly the batch-changed files.
+prop_batch_commit :: Property
+prop_batch_commit = H.propertyOnce $ do
+  (commitMsg, changedFiles') <- H.evalIO $ setupBatchRepo $ \tmpDir -> do
+    Just result <- batchPackage testConfigMultiProject tmpDir "cardano-api" Nothing testDay
+    commitBatchResult tmpDir result Commit
+    msg <- readGit tmpDir ["log", "-1", "--format=%s"]
+    files <- readGit tmpDir ["diff", "--name-only", "HEAD~1", "HEAD"]
+    pure (msg, files)
+
+  T.pack commitMsg `shouldContain` "Release cardano-api-8.5.0.0"
+
+  let files = sort . filter (not . null) . lines $ changedFiles'
+  H.assert $ ".changes/42-fix-serialization.yml" `elem` files
+  H.assert $ ".changes/99-add-conway-support.yml" `elem` files
+  H.assert $ "cardano-api/CHANGELOG.md" `elem` files
+  H.assert $ "cardano-api/cardano-api.cabal" `elem` files
+  -- Other project's files should NOT be in the commit
+  H.assert . not $ any (T.isPrefixOf "cardano-api-gen" . T.pack) files
+
+-- | --commit-tag creates both a commit and a PACKAGE-VERSION tag.
+prop_batch_commit_tag :: Property
+prop_batch_commit_tag = H.propertyOnce $ do
+  tags <- H.evalIO $ setupBatchRepo $ \tmpDir -> do
+    Just result <- batchPackage testConfigMultiProject tmpDir "cardano-api" Nothing testDay
+    commitBatchResult tmpDir result CommitTag
+    readGit tmpDir ["tag", "-l"]
+
+  T.pack tags `shouldContain` "cardano-api-8.5.0.0"
+
+-- | Batching a project with no fragments returns Nothing (no-op with warning).
+prop_batch_no_fragments :: Property
+prop_batch_no_fragments = H.propertyOnce $ do
+  let configWithEmpty =
+        testConfigMultiProject
+          { configProjects =
+              Map.insert
+                "empty-project"
+                ProjectConfig
+                  { projectChangelog = "empty-project/CHANGELOG.md"
+                  , projectCabalFile = Nothing
+                  }
+                $ configProjects testConfigMultiProject
+          }
+  result <- H.evalIO $ setupTestRepo $ \tmpDir ->
+    batchPackage configWithEmpty tmpDir "empty-project" Nothing testDay
+
+  H.assert $ isNothing result
+
+-- | Batching the same project twice: first succeeds, second returns Nothing (fragments consumed).
+prop_batch_twice :: Property
+prop_batch_twice = H.propertyOnce $ do
+  (first, second) <- H.evalIO $ setupTestRepo $ \tmpDir -> do
+    r1 <- batchPackage testConfigMultiProject tmpDir "cardano-api" Nothing testDay
+    r2 <- batchPackage testConfigMultiProject tmpDir "cardano-api" Nothing testDay
+    pure (r1, r2)
+
+  H.assert $ isJust first
+  H.assert $ isNothing second
+
+-- | Explicit version lower than current is rejected as a hard error.
+prop_batch_downgrade :: Property
+prop_batch_downgrade = H.propertyOnce $ do
+  caught <- H.evalIO $ setupTestRepo $ \tmpDir ->
+    -- Current version is 8.4.1.2; requesting 1.0.0.0 is a downgrade
+    (batchPackage testConfigMultiProject tmpDir "cardano-api" (Just $ pvp 1 0 0 0) testDay >> pure False)
+      `catch` \(HeraldException _) -> pure True
+
+  H.assert caught
+
+-- | Batching twice with fresh fragments each time produces two changelog sections.
+prop_batch_idempotent :: Property
+prop_batch_idempotent = H.propertyOnce $ do
+  changelog <- H.evalIO $ setupTestRepo $ \tmpDir -> do
+    -- First batch
+    Just _ <- batchPackage testConfigMultiProject tmpDir "cardano-api" Nothing testDay
+    -- Add new fragments for a second batch
+    Yaml.encodeFile
+      (tmpDir </> ".changes" </> "200-new-feature.yml")
+      Fragment
+        { fragmentProject = "cardano-api"
+        , fragmentKinds = ["feature"]
+        , fragmentDescription = "New feature after first batch"
+        , fragmentPR = 200
+        }
+    let day2 = fromGregorian 2026 4 1
+    Just _ <- batchPackage testConfigMultiProject tmpDir "cardano-api" Nothing day2
+    T.readFile $ tmpDir </> "cardano-api" </> "CHANGELOG.md"
+
+  -- Both sections present
+  changelog `shouldContain` "## 8.5.0.0"
+  changelog `shouldContain` "## 8.5.1.0"
+
+-- | Batching a project with no .cabal file works when an explicit version is given.
+prop_batch_no_cabal :: Property
+prop_batch_no_cabal = H.propertyOnce $ do
+  let noCabalConfig =
+        testConfigMultiProject
+          { configProjects =
+              Map.fromList
+                [
+                  ( "cardano-api"
+                  , ProjectConfig
+                      { projectChangelog = "cardano-api/CHANGELOG.md"
+                      , projectCabalFile = Nothing
+                      }
+                  )
+                ]
+          }
+  (result, changelog) <- H.evalIO $ setupTestRepo $ \tmpDir -> do
+    r <- batchPackage noCabalConfig tmpDir "cardano-api" (Just $ pvp 2 0 0 0) testDay
+    cl <- T.readFile $ tmpDir </> "cardano-api" </> "CHANGELOG.md"
+    pure (r, cl)
+
+  H.assert $ isJust result
+  changelog `shouldContain` "## 2.0.0.0"
+
+-- | A fragment with an unknown kind causes batch to fail before modifying any files.
+prop_batch_invalid_fragment :: Property
+prop_batch_invalid_fragment = H.propertyOnce $ do
+  (caught, changelogUnchanged) <- H.evalIO $ setupTestRepo $ \tmpDir -> do
+    -- Write a fragment with an invalid kind
+    Yaml.encodeFile
+      (tmpDir </> ".changes" </> "999-bad-kind.yml")
+      Fragment
+        { fragmentProject = "cardano-api"
+        , fragmentKinds = ["nonexistent-kind"]
+        , fragmentDescription = "This should fail"
+        , fragmentPR = 999
+        }
+    changelogBefore <- T.readFile $ tmpDir </> "cardano-api" </> "CHANGELOG.md"
+    wasCaught <-
+      (batchPackage testConfigMultiProject tmpDir "cardano-api" (Just $ pvp 9 0 0 0) testDay >> pure False)
+        `catch` \(HeraldException _) -> pure True
+    changelogAfter <- T.readFile $ tmpDir </> "cardano-api" </> "CHANGELOG.md"
+    pure (wasCaught, changelogBefore == changelogAfter)
+
+  H.assert caught
+  H.assert changelogUnchanged
+
+-- | Auto-version without a cabal-file configured is rejected because there is
+-- no current version to bump from.
+prop_batch_auto_no_cabal :: Property
+prop_batch_auto_no_cabal = H.propertyOnce $ do
+  let noCabalConfig =
+        testConfigMultiProject
+          { configProjects =
+              Map.fromList
+                [
+                  ( "cardano-api"
+                  , ProjectConfig
+                      { projectChangelog = "cardano-api/CHANGELOG.md"
+                      , projectCabalFile = Nothing
+                      }
+                  )
+                ]
+          }
+  caught <- H.evalIO $ setupTestRepo $ \tmpDir ->
+    (batchPackage noCabalConfig tmpDir "cardano-api" Nothing testDay >> pure False)
+      `catch` \(HeraldException _) -> pure True
+
+  H.assert caught
+
+-- | Auto-version fails when the .cabal file has no version: line, since there
+-- is no base version to compute the bump from.
+prop_batch_auto_missing_version :: Property
+prop_batch_auto_missing_version = H.propertyOnce $ do
+  caught <- H.evalIO $ withSystemTempDirectory "herald-batch" $ \tmpDir -> do
+    let changesDir = tmpDir </> ".changes"
+        pkgDir = tmpDir </> "cardano-api"
+    createDirectoryIfMissing True changesDir
+    createDirectoryIfMissing True pkgDir
+    writeFile
+      (pkgDir </> "cardano-api.cabal")
+      "cabal-version: 3.0\nname: cardano-api\n"
+    T.writeFile (pkgDir </> "CHANGELOG.md") "## Old\n\n- Previous\n"
+    Yaml.encodeFile
+      (changesDir </> "42-fix.yml")
+      Fragment
+        { fragmentProject = "cardano-api"
+        , fragmentKinds = ["bugfix"]
+        , fragmentDescription = "Fix something"
+        , fragmentPR = 42
+        }
+    (batchPackage testConfigMultiProject tmpDir "cardano-api" Nothing testDay >> pure False)
+      `catch` \(HeraldException _) -> pure True
+
+  H.assert caught
+
+-- | Explicit version equal to the current .cabal version is accepted -- the
+-- downgrade check only rejects strictly lower versions.
+prop_batch_same_version :: Property
+prop_batch_same_version = H.propertyOnce $ do
+  result <- H.evalIO $ setupTestRepo $ \tmpDir ->
+    -- Current version in setupTestRepo is 8.4.1.2
+    batchPackage testConfigMultiProject tmpDir "cardano-api" (Just $ pvp 8 4 1 2) testDay
+
+  H.assert $ isJust result
+
+-- | Batching a project that does not exist in the config is rejected.
+prop_batch_unknown_project :: Property
+prop_batch_unknown_project = H.propertyOnce $ do
+  caught <- H.evalIO $ setupTestRepo $ \tmpDir ->
+    (batchPackage testConfigMultiProject tmpDir "nonexistent" Nothing testDay >> pure False)
+      `catch` \(HeraldException _) -> pure True
+
+  H.assert caught
+
+-- | When the .cabal file has no parseable version: line, the downgrade check
+-- is silently skipped because there is no current version to compare against.
+-- An explicit version succeeds regardless of what it is.
+prop_batch_downgrade_skipped_missing_version :: Property
+prop_batch_downgrade_skipped_missing_version = H.propertyOnce $ do
+  result <- H.evalIO $ withSystemTempDirectory "herald-batch" $ \tmpDir -> do
+    let changesDir = tmpDir </> ".changes"
+        pkgDir = tmpDir </> "cardano-api"
+    createDirectoryIfMissing True changesDir
+    createDirectoryIfMissing True pkgDir
+    writeFile
+      (pkgDir </> "cardano-api.cabal")
+      "cabal-version: 3.0\nname: cardano-api\n"
+    T.writeFile (pkgDir </> "CHANGELOG.md") "## Old\n\n- Previous\n"
+    Yaml.encodeFile
+      (changesDir </> "42-fix.yml")
+      Fragment
+        { fragmentProject = "cardano-api"
+        , fragmentKinds = ["bugfix"]
+        , fragmentDescription = "Fix something"
+        , fragmentPR = 42
+        }
+    -- 1.0.0.0 could be a downgrade, but no current version to compare against
+    batchPackage testConfigMultiProject tmpDir "cardano-api" (Just $ pvp 1 0 0 0) testDay
+
+  H.assert $ isJust result
+
+-- | A fragment mixing valid and invalid kinds is rejected -- a valid kind does
+-- not mask an invalid one.
+prop_batch_mixed_valid_invalid_kinds :: Property
+prop_batch_mixed_valid_invalid_kinds = H.propertyOnce $ do
+  caught <- H.evalIO $ setupTestRepo $ \tmpDir -> do
+    Yaml.encodeFile
+      (tmpDir </> ".changes" </> "999-mixed.yml")
+      Fragment
+        { fragmentProject = "cardano-api"
+        , fragmentKinds = ["bugfix", "nonexistent-kind"]
+        , fragmentDescription = "Mixed kinds"
+        , fragmentPR = 999
+        }
+    (batchPackage testConfigMultiProject tmpDir "cardano-api" (Just $ pvp 9 0 0 0) testDay >> pure False)
+      `catch` \(HeraldException _) -> pure True
+
+  H.assert caught
+
+-- | Batching when CHANGELOG.md does not exist on disk is a hard error.
+prop_batch_missing_changelog :: Property
+prop_batch_missing_changelog = H.propertyOnce $ do
+  caught <- H.evalIO $ withSystemTempDirectory "herald-batch" $ \tmpDir -> do
+    let changesDir = tmpDir </> ".changes"
+        pkgDir = tmpDir </> "cardano-api"
+    createDirectoryIfMissing True changesDir
+    createDirectoryIfMissing True pkgDir
+    writeFile
+      (pkgDir </> "cardano-api.cabal")
+      $ unlines ["cabal-version: 3.0", "name: cardano-api", "version: 8.4.1.2"]
+    -- Deliberately do NOT create CHANGELOG.md
+    Yaml.encodeFile
+      (changesDir </> "42-fix.yml")
+      Fragment
+        { fragmentProject = "cardano-api"
+        , fragmentKinds = ["bugfix"]
+        , fragmentDescription = "Fix something"
+        , fragmentPR = 42
+        }
+    (batchPackage testConfigMultiProject tmpDir "cardano-api" Nothing testDay >> pure False)
+      `catch` \(_ :: SomeException) -> pure True
+
+  H.assert caught
+
+-- | Batching when the configured .cabal file does not exist on disk is a hard error.
+prop_batch_missing_cabal_file :: Property
+prop_batch_missing_cabal_file = H.propertyOnce $ do
+  caught <- H.evalIO $ withSystemTempDirectory "herald-batch" $ \tmpDir -> do
+    let changesDir = tmpDir </> ".changes"
+        pkgDir = tmpDir </> "cardano-api"
+    createDirectoryIfMissing True changesDir
+    createDirectoryIfMissing True pkgDir
+    -- Deliberately do NOT create .cabal file
+    T.writeFile (pkgDir </> "CHANGELOG.md") "## Old\n\n- Previous\n"
+    Yaml.encodeFile
+      (changesDir </> "42-fix.yml")
+      Fragment
+        { fragmentProject = "cardano-api"
+        , fragmentKinds = ["bugfix"]
+        , fragmentDescription = "Fix something"
+        , fragmentPR = 42
+        }
+    -- Auto-version needs the .cabal file to read current version
+    (batchPackage testConfigMultiProject tmpDir "cardano-api" Nothing testDay >> pure False)
+      `catch` \(_ :: SomeException) -> pure True
+
+  H.assert caught
+
+-------------------------------------------------------------------------------
+-- Helpers
+-------------------------------------------------------------------------------
+
+-- | Run a git command and return its stdout.
+readGit :: FilePath -> [String] -> IO String
+readGit dir args = do
+  (_, out, _) <- readProcessWithExitCode "git" (["-C", dir] <> args) ""
+  pure out

--- a/herald/test-e2e/Test/Herald/E2E/Fixtures.hs
+++ b/herald/test-e2e/Test/Herald/E2E/Fixtures.hs
@@ -1,0 +1,331 @@
+-- | Shared setup helpers, configs, and git utilities for e2e tests.
+module Test.Herald.E2E.Fixtures
+  ( -- * Git helpers
+    git
+  , withGitRepo
+  , commitAll
+  , withFakeOrigin
+  , withFeatureBranch
+
+    -- * Repo setup
+  , setupTestRepo
+  , setupBatchRepo
+  , setupDiffRepo
+  , setupMultiDiffRepo
+  , setupRootDiffRepo
+
+    -- * Configs
+  , testConfigDiffRepo
+  , testConfigMultiDiffRepo
+  , testConfigRootDiffRepo
+  )
+where
+
+import Data.Map.Strict qualified as Map
+import Data.Text.IO qualified as T
+import Data.Yaml qualified as Yaml
+import System.Directory (createDirectoryIfMissing)
+import System.Exit (ExitCode (..))
+import System.FilePath (takeDirectory, (</>))
+import System.IO.Temp (withSystemTempDirectory)
+import System.Process (readProcessWithExitCode)
+
+import Test.Herald.Fixtures (testConfigMultiProject)
+
+import Herald.Types (Config (..), Fragment (..), ProjectConfig (..))
+
+-------------------------------------------------------------------------------
+-- Git helpers
+-------------------------------------------------------------------------------
+
+-- | Run a git command in a directory, failing on non-zero exit.
+git :: FilePath -> [String] -> IO ()
+git dir args = do
+  (code, _, err) <- readProcessWithExitCode "git" (["-C", dir] <> args) ""
+  case code of
+    ExitSuccess -> pure ()
+    _ -> error $ "git " <> unwords args <> " failed: " <> err
+
+-- | Create a temp directory with an initialized git repo (main branch).
+withGitRepo :: String -> (FilePath -> IO a) -> IO a
+withGitRepo label action = withSystemTempDirectory label $ \tmpDir -> do
+  git tmpDir ["init", "-b", "main"]
+  git tmpDir ["config", "user.email", "test@test.com"]
+  git tmpDir ["config", "user.name", "Test"]
+  action tmpDir
+
+-- | Stage all files and commit.
+commitAll :: FilePath -> String -> IO ()
+commitAll dir msg = do
+  git dir ["add", "-A"]
+  git dir ["commit", "-m", msg]
+
+-- | Set up a fake origin remote pointing at the repo itself,
+-- so that defaultRemoteBranch can resolve origin/main.
+withFakeOrigin :: FilePath -> IO ()
+withFakeOrigin dir = do
+  git dir ["remote", "add", "origin", dir]
+  git dir ["fetch", "origin"]
+  let headPath = dir </> ".git" </> "refs" </> "remotes" </> "origin" </> "HEAD"
+  createDirectoryIfMissing True $ takeDirectory headPath
+  writeFile headPath "ref: refs/remotes/origin/main\n"
+
+-- | Create a feature branch off current HEAD with a fake origin set up.
+withFeatureBranch :: FilePath -> IO a -> IO a
+withFeatureBranch dir action = do
+  withFakeOrigin dir
+  git dir ["checkout", "-b", "feature"]
+  action
+
+-------------------------------------------------------------------------------
+-- Test repo setups
+-------------------------------------------------------------------------------
+
+-- | Temp directory with two projects, three fragment files, .cabal and CHANGELOG files.
+-- No git repo -- just the filesystem layout.
+setupTestRepo :: (FilePath -> IO a) -> IO a
+setupTestRepo action = withSystemTempDirectory "herald-e2e" $ \tmpDir -> do
+  let changesDir = tmpDir </> ".changes"
+      cardanoApiDir = tmpDir </> "cardano-api"
+      cardanoApiGenDir = tmpDir </> "cardano-api-gen"
+
+  createDirectoryIfMissing True changesDir
+  createDirectoryIfMissing True cardanoApiDir
+  createDirectoryIfMissing True cardanoApiGenDir
+
+  -- Fragment files
+  Yaml.encodeFile
+    (changesDir </> "42-fix-serialization.yml")
+    Fragment
+      { fragmentProject = "cardano-api"
+      , fragmentKinds = ["bugfix"]
+      , fragmentDescription = "Fix serialization of Conway certificates"
+      , fragmentPR = 42
+      }
+
+  Yaml.encodeFile
+    (changesDir </> "99-add-conway-support.yml")
+    Fragment
+      { fragmentProject = "cardano-api"
+      , fragmentKinds = ["breaking", "feature"]
+      , fragmentDescription = "Add Conway era support"
+      , fragmentPR = 99
+      }
+
+  Yaml.encodeFile
+    (changesDir </> "50-gen-helpers.yml")
+    Fragment
+      { fragmentProject = "cardano-api-gen"
+      , fragmentKinds = ["test"]
+      , fragmentDescription = "Add generator helpers"
+      , fragmentPR = 50
+      }
+
+  -- .cabal files
+  writeFile
+    (cardanoApiDir </> "cardano-api.cabal")
+    $ unlines
+      [ "cabal-version: 3.0"
+      , "name:          cardano-api"
+      , "version:       8.4.1.2"
+      , "synopsis:      Cardano API"
+      , ""
+      , "library"
+      , "  build-depends: base"
+      ]
+
+  writeFile
+    (cardanoApiGenDir </> "cardano-api-gen.cabal")
+    $ unlines
+      [ "cabal-version: 3.0"
+      , "name:          cardano-api-gen"
+      , "version:       1.0.0.0"
+      , "synopsis:      Cardano API generators"
+      , ""
+      , "library"
+      , "  build-depends: base"
+      ]
+
+  -- CHANGELOG.md files
+  T.writeFile
+    (cardanoApiDir </> "CHANGELOG.md")
+    "## 8.4.1.2 -- 2026-01-15\n\n- Previous change\n  (bugfix)\n  [PR 10](https://github.com/IntersectMBO/cardano-api/pull/10)\n"
+
+  T.writeFile
+    (cardanoApiGenDir </> "CHANGELOG.md")
+    "## 1.0.0.0 -- 2026-01-01\n\n- Initial release\n  (feature)\n  [PR 1](https://github.com/IntersectMBO/cardano-api/pull/1)\n"
+
+  action tmpDir
+
+-- | Same layout as setupTestRepo but inside an initialized git repo with an initial commit.
+setupBatchRepo :: (FilePath -> IO a) -> IO a
+setupBatchRepo action = withGitRepo "herald-batch" $ \tmpDir -> do
+  let changesDir = tmpDir </> ".changes"
+      cardanoApiDir = tmpDir </> "cardano-api"
+      cardanoApiGenDir = tmpDir </> "cardano-api-gen"
+
+  createDirectoryIfMissing True changesDir
+  createDirectoryIfMissing True cardanoApiDir
+  createDirectoryIfMissing True cardanoApiGenDir
+
+  Yaml.encodeFile
+    (changesDir </> "42-fix-serialization.yml")
+    Fragment
+      { fragmentProject = "cardano-api"
+      , fragmentKinds = ["bugfix"]
+      , fragmentDescription = "Fix serialization of Conway certificates"
+      , fragmentPR = 42
+      }
+  Yaml.encodeFile
+    (changesDir </> "99-add-conway-support.yml")
+    Fragment
+      { fragmentProject = "cardano-api"
+      , fragmentKinds = ["breaking", "feature"]
+      , fragmentDescription = "Add Conway era support"
+      , fragmentPR = 99
+      }
+  Yaml.encodeFile
+    (changesDir </> "50-gen-helpers.yml")
+    Fragment
+      { fragmentProject = "cardano-api-gen"
+      , fragmentKinds = ["test"]
+      , fragmentDescription = "Add generator helpers"
+      , fragmentPR = 50
+      }
+
+  writeFile
+    (cardanoApiDir </> "cardano-api.cabal")
+    $ unlines
+      [ "cabal-version: 3.0"
+      , "name:          cardano-api"
+      , "version:       8.4.1.2"
+      , "synopsis:      Cardano API"
+      , ""
+      , "library"
+      , "  build-depends: base"
+      ]
+  writeFile
+    (cardanoApiGenDir </> "cardano-api-gen.cabal")
+    $ unlines
+      [ "cabal-version: 3.0"
+      , "name:          cardano-api-gen"
+      , "version:       1.0.0.0"
+      , "synopsis:      Cardano API generators"
+      , ""
+      , "library"
+      , "  build-depends: base"
+      ]
+  T.writeFile (cardanoApiDir </> "CHANGELOG.md") "## 8.4.1.2\n\n- Previous change\n"
+  T.writeFile (cardanoApiGenDir </> "CHANGELOG.md") "## 1.0.0.0\n\n- Initial release\n"
+
+  commitAll tmpDir "initial"
+  action tmpDir
+
+-- | Git repo with a single project (my-lib), committed on main, then switched to a feature branch.
+setupDiffRepo :: (FilePath -> IO a) -> IO a
+setupDiffRepo action = withGitRepo "herald-diff" $ \tmpDir -> do
+  let pkgDir = tmpDir </> "my-lib"
+  createDirectoryIfMissing True pkgDir
+  writeFile
+    (pkgDir </> "my-lib.cabal")
+    "cabal-version: 3.0\nname: my-lib\nversion: 1.0.0.0\n"
+  T.writeFile (pkgDir </> "CHANGELOG.md") "## 1.0.0.0\n\n- Initial\n"
+  createDirectoryIfMissing True $ tmpDir </> ".changes"
+  Yaml.encodeFile (tmpDir </> ".herald.yml") testConfigDiffRepo
+
+  commitAll tmpDir "initial"
+  withFeatureBranch tmpDir $ action tmpDir
+
+-- | Git repo with two subprojects (lib-a, lib-b), committed on main, then switched to a feature branch.
+setupMultiDiffRepo :: (FilePath -> IO a) -> IO a
+setupMultiDiffRepo action = withGitRepo "herald-multi-diff" $ \tmpDir -> do
+  let libA = tmpDir </> "lib-a"
+      libB = tmpDir </> "lib-b"
+  createDirectoryIfMissing True libA
+  createDirectoryIfMissing True libB
+  writeFile (libA </> "lib-a.cabal") "cabal-version: 3.0\nname: lib-a\nversion: 1.0.0.0\n"
+  writeFile (libB </> "lib-b.cabal") "cabal-version: 3.0\nname: lib-b\nversion: 1.0.0.0\n"
+  T.writeFile (libA </> "CHANGELOG.md") "## 1.0.0.0\n\n- Initial\n"
+  T.writeFile (libB </> "CHANGELOG.md") "## 1.0.0.0\n\n- Initial\n"
+  createDirectoryIfMissing True $ tmpDir </> ".changes"
+
+  commitAll tmpDir "initial"
+  withFeatureBranch tmpDir $ action tmpDir
+
+-- | Git repo with a single root-level project (my-tool.cabal in root), on a feature branch.
+setupRootDiffRepo :: (FilePath -> IO a) -> IO a
+setupRootDiffRepo action = withGitRepo "herald-root-diff" $ \tmpDir -> do
+  writeFile (tmpDir </> "my-tool.cabal") "cabal-version: 3.0\nname: my-tool\nversion: 1.0.0.0\n"
+  T.writeFile (tmpDir </> "CHANGELOG.md") "## 1.0.0.0\n\n- Initial\n"
+  createDirectoryIfMissing True $ tmpDir </> ".changes"
+
+  commitAll tmpDir "initial"
+  withFeatureBranch tmpDir $ action tmpDir
+
+-------------------------------------------------------------------------------
+-- Test configs
+-------------------------------------------------------------------------------
+
+-- | Config for the single-project diff test repo.
+testConfigDiffRepo :: Config
+testConfigDiffRepo =
+  Config
+    { configGitRepo = "https://github.com/test/repo"
+    , configChangesDir = ".changes"
+    , configKinds = configKinds testConfigMultiProject
+    , configProjects =
+        Map.fromList
+          [
+            ( "my-lib"
+            , ProjectConfig
+                { projectChangelog = "my-lib/CHANGELOG.md"
+                , projectCabalFile = Just "my-lib/my-lib.cabal"
+                }
+            )
+          ]
+    }
+
+-- | Config for the two-project diff test repo.
+testConfigMultiDiffRepo :: Config
+testConfigMultiDiffRepo =
+  Config
+    { configGitRepo = "https://github.com/test/repo"
+    , configChangesDir = ".changes"
+    , configKinds = configKinds testConfigMultiProject
+    , configProjects =
+        Map.fromList
+          [
+            ( "lib-a"
+            , ProjectConfig
+                { projectChangelog = "lib-a/CHANGELOG.md"
+                , projectCabalFile = Just "lib-a/lib-a.cabal"
+                }
+            )
+          ,
+            ( "lib-b"
+            , ProjectConfig
+                { projectChangelog = "lib-b/CHANGELOG.md"
+                , projectCabalFile = Just "lib-b/lib-b.cabal"
+                }
+            )
+          ]
+    }
+
+-- | Config for the root-level single-project diff repo.
+testConfigRootDiffRepo :: Config
+testConfigRootDiffRepo =
+  Config
+    { configGitRepo = "https://github.com/test/repo"
+    , configChangesDir = ".changes"
+    , configKinds = configKinds testConfigMultiProject
+    , configProjects =
+        Map.fromList
+          [
+            ( "my-tool"
+            , ProjectConfig
+                { projectChangelog = "CHANGELOG.md"
+                , projectCabalFile = Just "my-tool.cabal"
+                }
+            )
+          ]
+    }

--- a/herald/test-e2e/Test/Herald/E2E/Fragment.hs
+++ b/herald/test-e2e/Test/Herald/E2E/Fragment.hs
@@ -1,0 +1,135 @@
+module Test.Herald.E2E.Fragment (tests) where
+
+import Control.Exception (catch)
+import Data.Text qualified as T
+import Data.Text.IO qualified as T
+import System.Directory (doesFileExist)
+import System.FilePath (takeFileName, (</>))
+
+import Hedgehog (Property)
+import Hedgehog qualified as H
+import Hedgehog.Extras qualified as H
+import Test.Herald.Assertions (shouldContain)
+import Test.Herald.E2E.Fixtures (setupTestRepo)
+import Test.Herald.Fixtures (testConfigMultiProject)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Hedgehog (testProperty)
+
+import Herald.Command.New (NewOptions (..), createFragment)
+import Herald.Fragment.Read (readAllFragments)
+import Herald.Types (HeraldException (..))
+
+tests :: TestTree
+tests =
+  testGroup
+    "Fragment creation"
+    [ testProperty "multi-project produces distinct files" prop_create_fragment_multi_project
+    , testProperty "spaces in description produce clean filename" prop_create_fragment_spaces
+    , testProperty "template fragment is skipped by reading" prop_template_skipped
+    , testProperty "duplicate fragment for same PR errors with pointer" prop_duplicate_fragment
+    , testProperty "same PR different project is allowed" prop_cross_project_duplicate_pr
+    , testProperty "invalid project in createFragment errors before writing" prop_invalid_project
+    , testProperty "invalid kind in createFragment errors before writing" prop_invalid_kind
+    ]
+
+-- | Creating fragments for two different projects produces two distinct .yml files.
+prop_create_fragment_multi_project :: Property
+prop_create_fragment_multi_project = H.propertyOnce $ do
+  (path1, path2) <- H.evalIO $ setupTestRepo $ \tmpDir -> do
+    let opts1 = NewOptions "cardano-api" ["breaking", "feature"] "foo" 6777
+        opts2 = NewOptions "cardano-api-gen" ["breaking", "feature"] "foo" 6777
+    p1 <- createFragment testConfigMultiProject tmpDir opts1
+    p2 <- createFragment testConfigMultiProject tmpDir opts2
+    assertFileExists p1
+    assertFileExists p2
+    pure (p1, p2)
+
+  H.assert $ T.isSuffixOf ".yml" $ T.pack path1
+  H.assert $ T.isSuffixOf ".yml" $ T.pack path2
+
+-- | Spaces in description are converted to hyphens in the filename (no spaces in filenames).
+prop_create_fragment_spaces :: Property
+prop_create_fragment_spaces = H.propertyOnce $ do
+  path <- H.evalIO $ setupTestRepo $ \tmpDir -> do
+    let opts = NewOptions "cardano-api" ["bugfix"] "Fix serialization of Conway certificates" 777
+    p <- createFragment testConfigMultiProject tmpDir opts
+    assertFileExists p
+    pure p
+
+  H.assert $ notElem ' ' $ takeFileName path
+
+-- | _TEMPLATE.yml is not returned by readAllFragments.
+prop_template_skipped :: Property
+prop_template_skipped = H.propertyOnce $ do
+  fragments <- H.evalIO $ setupTestRepo $ \tmpDir -> do
+    T.writeFile
+      (tmpDir </> ".changes" </> "_TEMPLATE.yml")
+      "project: cardano-api\nkind:\n  - bugfix\ndescription: template\npr: 0\n"
+    readAllFragments testConfigMultiProject tmpDir
+
+  let names = map fst fragments
+  H.assert $ "_TEMPLATE.yml" `notElem` names
+
+-- | Creating a fragment for a PR that already has one errors and names the existing file.
+prop_duplicate_fragment :: Property
+prop_duplicate_fragment = H.propertyOnce $ do
+  errMsg <- H.evalIO $ setupTestRepo $ \tmpDir -> do
+    -- Fragment for PR 42 already exists in setupTestRepo
+    let opts = NewOptions "cardano-api" ["bugfix"] "Duplicate attempt" 42
+    (createFragment testConfigMultiProject tmpDir opts >> pure "no error")
+      `catch` \(HeraldException msg) -> pure msg
+
+  T.pack errMsg `shouldContain` "already exists"
+  T.pack errMsg `shouldContain` "42-fix-serialization.yml"
+
+-- | Same PR number for a different project is allowed (duplicate check is per-project).
+prop_cross_project_duplicate_pr :: Property
+prop_cross_project_duplicate_pr = H.propertyOnce $ do
+  (path1, path2) <- H.evalIO $ setupTestRepo $ \tmpDir -> do
+    -- PR 42 already exists for cardano-api in setupTestRepo
+    -- Creating PR 42 for cardano-api-gen should succeed
+    let opts = NewOptions "cardano-api-gen" ["bugfix"] "Same PR different project" 42
+    p <- createFragment testConfigMultiProject tmpDir opts
+    assertFileExists p
+    -- Verify original still exists
+    let origPath = tmpDir </> ".changes" </> "42-fix-serialization.yml"
+    assertFileExists origPath
+    pure (p, origPath)
+
+  H.assert $ path1 /= path2
+
+-- | Creating a fragment with an unknown project errors before writing any file.
+prop_invalid_project :: Property
+prop_invalid_project = H.propertyOnce $ do
+  errMsg <- H.evalIO $ setupTestRepo $ \tmpDir ->
+    ( createFragment testConfigMultiProject tmpDir (NewOptions "nonexistent" ["bugfix"] "Desc" 999)
+        >> pure "no error"
+    )
+      `catch` \(HeraldException msg) -> pure msg
+
+  T.pack errMsg `shouldContain` "Invalid fragment"
+  T.pack errMsg `shouldContain` "Unknown project"
+
+-- | Creating a fragment with an unknown kind errors before writing any file.
+prop_invalid_kind :: Property
+prop_invalid_kind = H.propertyOnce $ do
+  errMsg <- H.evalIO $ setupTestRepo $ \tmpDir ->
+    ( createFragment
+        testConfigMultiProject
+        tmpDir
+        (NewOptions "cardano-api" ["nonexistent-kind"] "Desc" 999)
+        >> pure "no error"
+    )
+      `catch` \(HeraldException msg) -> pure msg
+
+  T.pack errMsg `shouldContain` "Invalid fragment"
+  T.pack errMsg `shouldContain` "Unknown kind"
+
+-------------------------------------------------------------------------------
+-- Helpers
+-------------------------------------------------------------------------------
+
+assertFileExists :: FilePath -> IO ()
+assertFileExists path = do
+  exists <- doesFileExist path
+  if exists then pure () else error $ "Fragment file not found: " <> path

--- a/herald/test-e2e/Test/Herald/E2E/Init.hs
+++ b/herald/test-e2e/Test/Herald/E2E/Init.hs
@@ -1,0 +1,161 @@
+module Test.Herald.E2E.Init (tests) where
+
+import Control.Exception (catch)
+import Data.Map.Strict qualified as Map
+import Data.Text qualified as T
+import Data.Text.IO qualified as T
+import System.Directory (createDirectoryIfMissing, doesFileExist)
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
+
+import Hedgehog (Property)
+import Hedgehog qualified as H
+import Hedgehog.Extras qualified as H
+import Test.Herald.Assertions (shouldContain)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Hedgehog (testProperty)
+
+import Herald.Command.Init (initConfig)
+import Herald.Config (loadConfig)
+import Herald.Types (Config (..), HeraldException (..))
+
+tests :: TestTree
+tests =
+  testGroup
+    "Init"
+    [ testProperty "skips directories with empty-name cabal files" prop_init_skips_empty_name
+    , testProperty "discovers non-cabal directories as projects" prop_init_non_cabal_dirs
+    , testProperty "discovers root-level single project" prop_init_root_project
+    , testProperty "creates template fragment" prop_init_creates_template
+    , testProperty "re-init on existing config errors" prop_init_existing_config
+    , testProperty "init with no remote fails" prop_init_no_remote
+    , testProperty "init with HTTPS remote extracts slug" prop_init_https_remote
+    ]
+
+-- | Directories containing .cabal files with empty basenames (e.g. .ghc-wasm/.cabal)
+-- are not included as projects.
+prop_init_skips_empty_name :: Property
+prop_init_skips_empty_name = H.propertyOnce $ do
+  config <- H.evalIO $ withFakeGitDir "herald-init" $ \tmpDir -> do
+    let bogusDir = tmpDir </> ".ghc-wasm"
+        goodDir = tmpDir </> "my-package"
+    createDirectoryIfMissing True bogusDir
+    createDirectoryIfMissing True goodDir
+    writeFile (bogusDir </> ".cabal") "cabal-version: 3.0\nname: ghost\n"
+    writeFile
+      (goodDir </> "my-package.cabal")
+      "cabal-version: 3.0\nname: my-package\nversion: 1.0.0.0\n"
+    initAndLoad tmpDir
+
+  let projectNames = Map.keys $ configProjects config
+  H.assert $ "my-package" `elem` projectNames
+  H.assert $ "" `notElem` projectNames
+
+-- | Subdirectories without .cabal files are still discovered using their directory name.
+prop_init_non_cabal_dirs :: Property
+prop_init_non_cabal_dirs = H.propertyOnce $ do
+  config <- H.evalIO $ withFakeGitDir "herald-init" $ \tmpDir -> do
+    let withCabal = tmpDir </> "my-lib"
+        withoutCabal = tmpDir </> "my-docs"
+    createDirectoryIfMissing True withCabal
+    createDirectoryIfMissing True withoutCabal
+    writeFile (withCabal </> "my-lib.cabal") "cabal-version: 3.0\nname: my-lib\nversion: 1.0.0.0\n"
+    initAndLoad tmpDir
+
+  let projectNames = Map.keys $ configProjects config
+  H.assert $ "my-lib" `elem` projectNames
+  H.assert $ "my-docs" `elem` projectNames
+
+-- | A single .cabal file in the root produces one project named after that file.
+prop_init_root_project :: Property
+prop_init_root_project = H.propertyOnce $ do
+  config <- H.evalIO $ withFakeGitDir "herald-init" $ \tmpDir -> do
+    writeFile (tmpDir </> "my-tool.cabal") "cabal-version: 3.0\nname: my-tool\nversion: 0.1.0.0\n"
+    initAndLoad tmpDir
+
+  let projects = Map.toList $ configProjects config
+  case projects of
+    [(name, _)] -> H.assert $ name == "my-tool"
+    _ -> H.failure
+
+-- | Init creates a _TEMPLATE.yml file containing the project and kind fields.
+prop_init_creates_template :: Property
+prop_init_creates_template = H.propertyOnce $ do
+  template <- H.evalIO $ withFakeGitDir "herald-init" $ \tmpDir -> do
+    let goodDir = tmpDir </> "my-pkg"
+    createDirectoryIfMissing True goodDir
+    writeFile (goodDir </> "my-pkg.cabal") "cabal-version: 3.0\nname: my-pkg\nversion: 1.0.0.0\n"
+
+    _ <- initConfig tmpDir (tmpDir </> ".herald.yml")
+    let templatePath = tmpDir </> ".changes" </> "_TEMPLATE.yml"
+    exists <- doesFileExist templatePath
+    if exists
+      then T.readFile templatePath
+      else error "Template fragment not created"
+
+  template `shouldContain` "project:"
+  template `shouldContain` "kind:"
+
+-- | Re-running init when .herald.yml already exists errors.
+prop_init_existing_config :: Property
+prop_init_existing_config = H.propertyOnce $ do
+  errMsg <- H.evalIO $ withFakeGitDir "herald-reinit" $ \tmpDir -> do
+    let configPath = tmpDir </> ".herald.yml"
+    writeFile configPath "existing config"
+    (initConfig tmpDir configPath >> pure "no error")
+      `catch` \(HeraldException msg) -> pure msg
+
+  T.pack errMsg `shouldContain` "already exists"
+
+-- | Init without a git remote (no .git/config with origin) errors.
+prop_init_no_remote :: Property
+prop_init_no_remote = H.propertyOnce $ do
+  errMsg <- H.evalIO $ withSystemTempDirectory "herald-no-remote" $ \tmpDir -> do
+    -- Create .git dir but no remote config
+    createDirectoryIfMissing True $ tmpDir </> ".git"
+    writeFile (tmpDir </> ".git" </> "config") "[core]\n\tbare = false\n"
+    writeFile (tmpDir </> ".git" </> "HEAD") "ref: refs/heads/main\n"
+    (initConfig tmpDir (tmpDir </> ".herald.yml") >> pure "no error")
+      `catch` \(HeraldException msg) -> pure msg
+
+  T.pack errMsg `shouldContain` "Could not detect origin remote"
+
+-- | Init with an HTTPS remote URL extracts the owner/repo slug.
+prop_init_https_remote :: Property
+prop_init_https_remote = H.propertyOnce $ do
+  config <- H.evalIO $ withSystemTempDirectory "herald-https" $ \tmpDir -> do
+    createDirectoryIfMissing True $ tmpDir </> ".git"
+    writeFile
+      (tmpDir </> ".git" </> "config")
+      "[remote \"origin\"]\n\turl = https://github.com/MyOrg/my-repo.git\n"
+    writeFile (tmpDir </> ".git" </> "HEAD") "ref: refs/heads/main\n"
+    let goodDir = tmpDir </> "my-pkg"
+    createDirectoryIfMissing True goodDir
+    writeFile (goodDir </> "my-pkg.cabal") "cabal-version: 3.0\nname: my-pkg\nversion: 1.0.0.0\n"
+    initAndLoad tmpDir
+
+  configGitRepo config `shouldContain` "https://github.com/MyOrg/my-repo"
+
+-------------------------------------------------------------------------------
+-- Helpers
+-------------------------------------------------------------------------------
+
+-- | Create a temp directory with a minimal .git dir (enough for detectGitRepo).
+withFakeGitDir :: String -> (FilePath -> IO a) -> IO a
+withFakeGitDir label action = withSystemTempDirectory label $ \tmpDir -> do
+  createDirectoryIfMissing True $ tmpDir </> ".git"
+  writeFile
+    (tmpDir </> ".git" </> "config")
+    "[remote \"origin\"]\n\turl = git@github.com:test/repo.git\n"
+  writeFile (tmpDir </> ".git" </> "HEAD") "ref: refs/heads/main\n"
+  action tmpDir
+
+-- | Run initConfig then loadConfig, failing on parse errors.
+initAndLoad :: FilePath -> IO Config
+initAndLoad tmpDir = do
+  let configPath = tmpDir </> ".herald.yml"
+  _ <- initConfig tmpDir configPath
+  result <- loadConfig configPath
+  case result of
+    Left err -> error $ "Failed to load generated config: " <> err
+    Right c -> pure c

--- a/herald/test-e2e/Test/Herald/E2E/Next.hs
+++ b/herald/test-e2e/Test/Herald/E2E/Next.hs
@@ -1,0 +1,168 @@
+module Test.Herald.E2E.Next (tests) where
+
+import Control.Exception (catch)
+import Data.Map.Strict qualified as Map
+import Data.Yaml qualified as Yaml
+import System.Directory (createDirectoryIfMissing)
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
+
+import Hedgehog (Property, (===))
+import Hedgehog qualified as H
+import Hedgehog.Extras qualified as H
+import Test.Herald.Fixtures (pvp, testConfigMultiProject)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Hedgehog (testProperty)
+
+import Herald.Command.Next (nextVersion)
+import Herald.Types (Config (..), Fragment (..), HeraldException (..), ProjectConfig (..))
+
+tests :: TestTree
+tests =
+  testGroup
+    "Next"
+    [ testProperty "next with no fragments returns Nothing" prop_next_no_fragments
+    , testProperty "next with no .cabal file returns Nothing" prop_next_no_cabal
+    , testProperty "next computes expected version" prop_next_computes_version
+    , testProperty "next rejects invalid fragments" prop_next_invalid_fragment
+    , testProperty "next with unknown project is rejected" prop_next_unknown_project
+    , testProperty "next with multiple kinds picks max bump" prop_next_multiple_kinds
+    ]
+
+-- | nextVersion with no unreleased fragments returns Nothing.
+prop_next_no_fragments :: Property
+prop_next_no_fragments = H.propertyOnce $ do
+  result <- H.evalIO $ withSystemTempDirectory "herald-next" $ \tmpDir -> do
+    let changesDir = tmpDir </> ".changes"
+        pkgDir = tmpDir </> "cardano-api"
+    createDirectoryIfMissing True changesDir
+    createDirectoryIfMissing True pkgDir
+    writeFile
+      (pkgDir </> "cardano-api.cabal")
+      "cabal-version: 3.0\nname: cardano-api\nversion: 8.4.1.2\n"
+    -- No fragment files
+    nextVersion testConfigMultiProject tmpDir "cardano-api"
+
+  result === Nothing
+
+-- | nextVersion with no .cabal file returns Nothing.
+prop_next_no_cabal :: Property
+prop_next_no_cabal = H.propertyOnce $ do
+  let noCabalConfig =
+        testConfigMultiProject
+          { configProjects =
+              Map.fromList
+                [
+                  ( "cardano-api"
+                  , ProjectConfig
+                      { projectChangelog = "cardano-api/CHANGELOG.md"
+                      , projectCabalFile = Nothing
+                      }
+                  )
+                ]
+          }
+  result <- H.evalIO $ withSystemTempDirectory "herald-next" $ \tmpDir -> do
+    let changesDir = tmpDir </> ".changes"
+    createDirectoryIfMissing True changesDir
+    Yaml.encodeFile
+      (changesDir </> "42-fix.yml")
+      Fragment
+        { fragmentProject = "cardano-api"
+        , fragmentKinds = ["bugfix"]
+        , fragmentDescription = "Fix"
+        , fragmentPR = 42
+        }
+    nextVersion noCabalConfig tmpDir "cardano-api"
+
+  result === Nothing
+
+-- | nextVersion with fragments computes the correct bumped version.
+prop_next_computes_version :: Property
+prop_next_computes_version = H.propertyOnce $ do
+  result <- H.evalIO $ withSystemTempDirectory "herald-next" $ \tmpDir -> do
+    let changesDir = tmpDir </> ".changes"
+        pkgDir = tmpDir </> "cardano-api"
+    createDirectoryIfMissing True changesDir
+    createDirectoryIfMissing True pkgDir
+    writeFile
+      (pkgDir </> "cardano-api.cabal")
+      "cabal-version: 3.0\nname: cardano-api\nversion: 8.4.1.2\n"
+    Yaml.encodeFile
+      (changesDir </> "42-fix.yml")
+      Fragment
+        { fragmentProject = "cardano-api"
+        , fragmentKinds = ["breaking"]
+        , fragmentDescription = "Breaking change"
+        , fragmentPR = 42
+        }
+    nextVersion testConfigMultiProject tmpDir "cardano-api"
+
+  result === Just (pvp 8 5 0 0)
+
+-- | A fragment with an unknown kind causes next to fail rather than silently
+-- ignoring the invalid kind.
+prop_next_invalid_fragment :: Property
+prop_next_invalid_fragment = H.propertyOnce $ do
+  caught <- H.evalIO $ withSystemTempDirectory "herald-next" $ \tmpDir -> do
+    let changesDir = tmpDir </> ".changes"
+        pkgDir = tmpDir </> "cardano-api"
+    createDirectoryIfMissing True changesDir
+    createDirectoryIfMissing True pkgDir
+    writeFile
+      (pkgDir </> "cardano-api.cabal")
+      "cabal-version: 3.0\nname: cardano-api\nversion: 8.4.1.2\n"
+    Yaml.encodeFile
+      (changesDir </> "999-bad-kind.yml")
+      Fragment
+        { fragmentProject = "cardano-api"
+        , fragmentKinds = ["nonexistent-kind"]
+        , fragmentDescription = "This should fail"
+        , fragmentPR = 999
+        }
+    (nextVersion testConfigMultiProject tmpDir "cardano-api" >> pure False)
+      `catch` \(HeraldException _) -> pure True
+
+  H.assert caught
+
+-- | nextVersion with an unknown project throws a HeraldException.
+prop_next_unknown_project :: Property
+prop_next_unknown_project = H.propertyOnce $ do
+  caught <- H.evalIO $ withSystemTempDirectory "herald-next" $ \tmpDir -> do
+    createDirectoryIfMissing True $ tmpDir </> ".changes"
+    (nextVersion testConfigMultiProject tmpDir "nonexistent-project" >> pure False)
+      `catch` \(HeraldException _) -> pure True
+
+  H.assert caught
+
+-- | nextVersion with fragments of different kinds picks the maximum bump.
+-- bugfix (patch) + feature (minor) -> feature bump wins.
+prop_next_multiple_kinds :: Property
+prop_next_multiple_kinds = H.propertyOnce $ do
+  result <- H.evalIO $ withSystemTempDirectory "herald-next" $ \tmpDir -> do
+    let changesDir = tmpDir </> ".changes"
+        pkgDir = tmpDir </> "cardano-api"
+    createDirectoryIfMissing True changesDir
+    createDirectoryIfMissing True pkgDir
+    writeFile
+      (pkgDir </> "cardano-api.cabal")
+      "cabal-version: 3.0\nname: cardano-api\nversion: 8.4.1.2\n"
+    Yaml.encodeFile
+      (changesDir </> "42-fix.yml")
+      Fragment
+        { fragmentProject = "cardano-api"
+        , fragmentKinds = ["bugfix"]
+        , fragmentDescription = "Fix something"
+        , fragmentPR = 42
+        }
+    Yaml.encodeFile
+      (changesDir </> "99-feature.yml")
+      Fragment
+        { fragmentProject = "cardano-api"
+        , fragmentKinds = ["feature"]
+        , fragmentDescription = "New feature"
+        , fragmentPR = 99
+        }
+    nextVersion testConfigMultiProject tmpDir "cardano-api"
+
+  -- Feature bump (0.0.1.0) > bugfix (0.0.0.1), so 8.4.1.2 -> 8.4.2.0
+  result === Just (pvp 8 4 2 0)

--- a/herald/test-e2e/Test/Herald/E2E/Validate.hs
+++ b/herald/test-e2e/Test/Herald/E2E/Validate.hs
@@ -1,0 +1,548 @@
+module Test.Herald.E2E.Validate (tests) where
+
+import Data.Text qualified as T
+import Data.Yaml qualified as Yaml
+import System.Directory (createDirectoryIfMissing)
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
+
+import Hedgehog (Property, (===))
+import Hedgehog qualified as H
+import Hedgehog.Extras qualified as H
+import Test.Herald.Assertions (shouldFail, shouldPass)
+import Test.Herald.E2E.Fixtures
+  ( commitAll
+  , git
+  , setupDiffRepo
+  , setupMultiDiffRepo
+  , setupRootDiffRepo
+  , setupTestRepo
+  , testConfigDiffRepo
+  , testConfigMultiDiffRepo
+  , testConfigRootDiffRepo
+  , withFeatureBranch
+  , withGitRepo
+  )
+import Test.Herald.Fixtures (testConfigMultiProject)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Hedgehog (testProperty)
+
+import Herald.Command.Validate (validateDiff, validateFiles, validatePR)
+import Herald.Fragment (validateFragment)
+import Herald.Types (Fragment (..))
+
+tests :: TestTree
+tests =
+  testGroup
+    "Validate"
+    [ testGroup
+        "validateFragment"
+        [ testProperty "validate rejects bad fragment" prop_validate_rejects_bad
+        , testProperty "valid fragment passes" prop_validate_fragment_valid
+        , testProperty "empty kinds list is rejected" prop_validate_fragment_empty_kinds
+        , testProperty "blank description is rejected" prop_validate_fragment_blank_desc
+        , testProperty "non-positive PR is rejected" prop_validate_fragment_bad_pr
+        , testProperty "unknown project is rejected" prop_validate_fragment_unknown_project
+        ]
+    , testGroup
+        "validateFiles"
+        [ testProperty "valid file on disk passes" prop_validate_files_valid
+        , testProperty "malformed YAML produces error" prop_validate_files_malformed
+        , testProperty "mix of good and bad reports only bad" prop_validate_files_mixed
+        ]
+    , testGroup
+        "validateDiff"
+        [ testProperty "missing fragment is detected" prop_validate_diff_missing
+        , testProperty "fragment present passes" prop_validate_diff_present
+        , testProperty "changes only in .changes/ are ignored" prop_validate_diff_changes_only
+        , testProperty "only modified project is flagged" prop_validate_diff_multi_project
+        , testProperty "root project detects changes" prop_validate_diff_root_project
+        , testProperty "no commits on feature branch passes" prop_validate_diff_no_commits
+        , testProperty "deleted files require fragment" prop_validate_diff_deleted
+        , testProperty
+            "pre-existing fragment does not satisfy new changes"
+            prop_validate_diff_preexisting_fragment
+        , testProperty
+            "fragment for wrong project does not satisfy"
+            prop_validate_diff_wrong_project
+        , testProperty
+            "malformed new fragment does not satisfy"
+            prop_validate_diff_malformed_fragment
+        , testProperty
+            "both projects modified, only one has fragment"
+            prop_validate_diff_multi_partial
+        , testProperty
+            "invalid fragment content still satisfies diff check"
+            prop_validate_diff_invalid_content_satisfies
+        ]
+    , testGroup
+        "validatePR"
+        [ testProperty "wrong PR number is detected" prop_validate_pr_mismatch
+        , testProperty "correct PR number passes" prop_validate_pr_match
+        , testProperty "only mismatched fragments reported" prop_validate_pr_partial_mismatch
+        , testProperty "template files are skipped" prop_validate_pr_skips_template
+        , testProperty ".yaml extension is also checked" prop_validate_pr_yaml_extension
+        , testProperty "no new fragments in diff passes" prop_validate_pr_no_new_fragments
+        , testProperty
+            "malformed fragment in diff reports parse error"
+            prop_validate_pr_malformed
+        , testProperty
+            "invalid fragment content with matching PR passes"
+            prop_validate_pr_invalid_content_passes
+        ]
+    , testGroup
+        "validateFiles edge cases"
+        [ testProperty "nonexistent file path produces error" prop_validate_files_nonexistent
+        ]
+    ]
+
+-------------------------------------------------------------------------------
+-- validateFragment
+-------------------------------------------------------------------------------
+
+-- | A fragment with an unknown kind produces validation errors.
+prop_validate_rejects_bad :: Property
+prop_validate_rejects_bad = H.propertyOnce $ do
+  let frag =
+        Fragment
+          { fragmentProject = "cardano-api"
+          , fragmentKinds = ["nonexistent-kind"]
+          , fragmentDescription = "Fix something"
+          , fragmentPR = 42
+          }
+  shouldFail $ validateFragment testConfigMultiProject frag
+
+-- | A well-formed fragment with known project and kind passes.
+prop_validate_fragment_valid :: Property
+prop_validate_fragment_valid = H.propertyOnce $ do
+  let frag =
+        Fragment
+          { fragmentProject = "cardano-api"
+          , fragmentKinds = ["bugfix"]
+          , fragmentDescription = "Fix something"
+          , fragmentPR = 42
+          }
+  shouldPass $ validateFragment testConfigMultiProject frag
+
+-- | A fragment with an empty kinds list is rejected.
+prop_validate_fragment_empty_kinds :: Property
+prop_validate_fragment_empty_kinds = H.propertyOnce $ do
+  let frag =
+        Fragment
+          { fragmentProject = "cardano-api"
+          , fragmentKinds = []
+          , fragmentDescription = "Fix something"
+          , fragmentPR = 42
+          }
+  shouldFail $ validateFragment testConfigMultiProject frag
+
+-- | A fragment with a blank description is rejected.
+prop_validate_fragment_blank_desc :: Property
+prop_validate_fragment_blank_desc = H.propertyOnce $ do
+  let frag =
+        Fragment
+          { fragmentProject = "cardano-api"
+          , fragmentKinds = ["bugfix"]
+          , fragmentDescription = "   "
+          , fragmentPR = 42
+          }
+  shouldFail $ validateFragment testConfigMultiProject frag
+
+-- | A fragment with a non-positive PR number is rejected.
+prop_validate_fragment_bad_pr :: Property
+prop_validate_fragment_bad_pr = H.propertyOnce $ do
+  let frag =
+        Fragment
+          { fragmentProject = "cardano-api"
+          , fragmentKinds = ["bugfix"]
+          , fragmentDescription = "Fix something"
+          , fragmentPR = 0
+          }
+  shouldFail $ validateFragment testConfigMultiProject frag
+
+-- | A fragment referencing an unknown project is rejected.
+prop_validate_fragment_unknown_project :: Property
+prop_validate_fragment_unknown_project = H.propertyOnce $ do
+  let frag =
+        Fragment
+          { fragmentProject = "nonexistent-package"
+          , fragmentKinds = ["bugfix"]
+          , fragmentDescription = "Fix something"
+          , fragmentPR = 42
+          }
+  shouldFail $ validateFragment testConfigMultiProject frag
+
+-------------------------------------------------------------------------------
+-- validateFiles
+-------------------------------------------------------------------------------
+
+-- | A well-formed fragment file on disk passes file validation.
+prop_validate_files_valid :: Property
+prop_validate_files_valid = H.propertyOnce $ do
+  errors <- H.evalIO $ setupTestRepo $ \tmpDir ->
+    validateFiles testConfigMultiProject [tmpDir </> ".changes" </> "42-fix-serialization.yml"]
+  shouldPass errors
+
+-- | Malformed YAML triggers a parse error.
+prop_validate_files_malformed :: Property
+prop_validate_files_malformed = H.propertyOnce $ do
+  errors <- H.evalIO $ withSystemTempDirectory "herald-validate" $ \tmpDir -> do
+    let path = tmpDir </> "bad.yml"
+    writeFile path "not: valid: yaml: [unterminated"
+    validateFiles testConfigMultiProject [path]
+  shouldFail errors
+
+-- | When validating a mix of good and bad files, only the bad file produces errors.
+prop_validate_files_mixed :: Property
+prop_validate_files_mixed = H.propertyOnce $ do
+  errors <- H.evalIO $ setupTestRepo $ \tmpDir -> do
+    let goodPath = tmpDir </> ".changes" </> "42-fix-serialization.yml"
+        badPath = tmpDir </> ".changes" </> "bad.yml"
+    writeFile badPath "not: valid: yaml: [unterminated"
+    validateFiles testConfigMultiProject [goodPath, badPath]
+  shouldFail errors
+  H.assert $ all (T.isInfixOf "bad.yml") errors
+
+-------------------------------------------------------------------------------
+-- validateDiff
+-------------------------------------------------------------------------------
+
+-- | Modifying a project file without adding a fragment triggers a diff error.
+prop_validate_diff_missing :: Property
+prop_validate_diff_missing = H.propertyOnce $ do
+  errors <- H.evalIO $ setupDiffRepo $ \tmpDir -> do
+    writeFile (tmpDir </> "my-lib" </> "Lib.hs") "module Lib where\n"
+    commitAll tmpDir "add lib"
+    validateDiff testConfigDiffRepo tmpDir
+
+  shouldFail errors
+  H.assert $ any (T.isInfixOf "my-lib") errors
+
+-- | Modifying a project file AND adding a matching fragment passes.
+prop_validate_diff_present :: Property
+prop_validate_diff_present = H.propertyOnce $ do
+  errors <- H.evalIO $ setupDiffRepo $ \tmpDir -> do
+    writeFile (tmpDir </> "my-lib" </> "Lib.hs") "module Lib where\n"
+    Yaml.encodeFile
+      (tmpDir </> ".changes" </> "123-add-lib.yml")
+      Fragment
+        { fragmentProject = "my-lib"
+        , fragmentKinds = ["feature"]
+        , fragmentDescription = "Add Lib module"
+        , fragmentPR = 123
+        }
+    commitAll tmpDir "add lib with fragment"
+    validateDiff testConfigDiffRepo tmpDir
+
+  shouldPass errors
+
+-- | Changes only inside .changes/ (no project source files touched) should not trigger errors.
+prop_validate_diff_changes_only :: Property
+prop_validate_diff_changes_only = H.propertyOnce $ do
+  errors <- H.evalIO $ setupDiffRepo $ \tmpDir -> do
+    Yaml.encodeFile
+      (tmpDir </> ".changes" </> "200-something.yml")
+      Fragment
+        { fragmentProject = "my-lib"
+        , fragmentKinds = ["bugfix"]
+        , fragmentDescription = "Something"
+        , fragmentPR = 200
+        }
+    commitAll tmpDir "add fragment only"
+    validateDiff testConfigDiffRepo tmpDir
+
+  shouldPass errors
+
+-- | In a multi-project repo, only the project with modified files (and no fragment) is flagged.
+prop_validate_diff_multi_project :: Property
+prop_validate_diff_multi_project = H.propertyOnce $ do
+  errors <- H.evalIO $ setupMultiDiffRepo $ \tmpDir -> do
+    writeFile (tmpDir </> "lib-a" </> "Foo.hs") "module Foo where\n"
+    commitAll tmpDir "modify lib-a"
+    validateDiff testConfigMultiDiffRepo tmpDir
+
+  shouldFail errors
+  H.assert $ any (T.isInfixOf "lib-a") errors
+  H.assert . not $ any (T.isInfixOf "lib-b") errors
+
+-- | A root-level project (changelog at ".") detects changes correctly.
+prop_validate_diff_root_project :: Property
+prop_validate_diff_root_project = H.propertyOnce $ do
+  errors <- H.evalIO $ setupRootDiffRepo $ \tmpDir -> do
+    writeFile (tmpDir </> "Main.hs") "module Main where\n"
+    commitAll tmpDir "add main"
+    validateDiff testConfigRootDiffRepo tmpDir
+
+  shouldFail errors
+  H.assert $ any (T.isInfixOf "my-tool") errors
+
+-------------------------------------------------------------------------------
+-- validatePR
+-------------------------------------------------------------------------------
+
+-- | A fragment with PR 123 is flagged when --pr expects 999.
+prop_validate_pr_mismatch :: Property
+prop_validate_pr_mismatch = H.propertyOnce $ do
+  errors <- H.evalIO $ setupDiffRepo $ \tmpDir -> do
+    Yaml.encodeFile
+      (tmpDir </> ".changes" </> "123-add-lib.yml")
+      Fragment
+        { fragmentProject = "my-lib"
+        , fragmentKinds = ["feature"]
+        , fragmentDescription = "Add Lib module"
+        , fragmentPR = 123
+        }
+    commitAll tmpDir "add fragment"
+    validatePR testConfigDiffRepo tmpDir 999
+
+  shouldFail errors
+  H.assert $ any (T.isInfixOf "does not match") errors
+
+-- | A fragment whose PR matches the expected number passes.
+prop_validate_pr_match :: Property
+prop_validate_pr_match = H.propertyOnce $ do
+  errors <- H.evalIO $ setupDiffRepo $ \tmpDir -> do
+    Yaml.encodeFile
+      (tmpDir </> ".changes" </> "123-add-lib.yml")
+      Fragment
+        { fragmentProject = "my-lib"
+        , fragmentKinds = ["feature"]
+        , fragmentDescription = "Add Lib module"
+        , fragmentPR = 123
+        }
+    commitAll tmpDir "add fragment"
+    validatePR testConfigDiffRepo tmpDir 123
+
+  shouldPass errors
+
+-- | With two fragments, only the one with a mismatched PR is reported.
+prop_validate_pr_partial_mismatch :: Property
+prop_validate_pr_partial_mismatch = H.propertyOnce $ do
+  errors <- H.evalIO $ setupDiffRepo $ \tmpDir -> do
+    Yaml.encodeFile
+      (tmpDir </> ".changes" </> "42-fix.yml")
+      Fragment
+        { fragmentProject = "my-lib"
+        , fragmentKinds = ["bugfix"]
+        , fragmentDescription = "Fix"
+        , fragmentPR = 42
+        }
+    Yaml.encodeFile
+      (tmpDir </> ".changes" </> "99-feature.yml")
+      Fragment
+        { fragmentProject = "my-lib"
+        , fragmentKinds = ["feature"]
+        , fragmentDescription = "Feature"
+        , fragmentPR = 99
+        }
+    commitAll tmpDir "add two fragments"
+    validatePR testConfigDiffRepo tmpDir 42
+
+  length errors === 1
+  H.assert $ any (T.isInfixOf "99") errors
+  H.assert . not $ any (T.isInfixOf "42-fix") errors
+
+-- | Template files (_TEMPLATE.yml) are skipped by PR validation.
+prop_validate_pr_skips_template :: Property
+prop_validate_pr_skips_template = H.propertyOnce $ do
+  errors <- H.evalIO $ setupDiffRepo $ \tmpDir -> do
+    writeFile
+      (tmpDir </> ".changes" </> "_TEMPLATE.yml")
+      "project: my-lib\nkind:\n  - bugfix\ndescription: template\npr: 0\n"
+    Yaml.encodeFile
+      (tmpDir </> ".changes" </> "42-fix.yml")
+      Fragment
+        { fragmentProject = "my-lib"
+        , fragmentKinds = ["bugfix"]
+        , fragmentDescription = "Fix"
+        , fragmentPR = 42
+        }
+    commitAll tmpDir "add template and fragment"
+    validatePR testConfigDiffRepo tmpDir 42
+
+  shouldPass errors
+
+-- | Fragments with .yaml extension (not just .yml) are also checked.
+prop_validate_pr_yaml_extension :: Property
+prop_validate_pr_yaml_extension = H.propertyOnce $ do
+  errors <- H.evalIO $ setupDiffRepo $ \tmpDir -> do
+    Yaml.encodeFile
+      (tmpDir </> ".changes" </> "55-old-style.yaml")
+      Fragment
+        { fragmentProject = "my-lib"
+        , fragmentKinds = ["bugfix"]
+        , fragmentDescription = "Old style"
+        , fragmentPR = 55
+        }
+    commitAll tmpDir "add yaml fragment"
+    validatePR testConfigDiffRepo tmpDir 99
+
+  shouldFail errors
+  H.assert $ any (T.isInfixOf "55") errors
+
+-- | A fragment committed on main before the fork point must not satisfy the
+-- requirement for new changes on the feature branch.
+prop_validate_diff_preexisting_fragment :: Property
+prop_validate_diff_preexisting_fragment = H.propertyOnce $ do
+  errors <- H.evalIO $ withGitRepo "herald-preexisting" $ \tmpDir -> do
+    let pkgDir = tmpDir </> "my-lib"
+    createDirectoryIfMissing True pkgDir
+    createDirectoryIfMissing True $ tmpDir </> ".changes"
+    writeFile (pkgDir </> "my-lib.cabal") "cabal-version: 3.0\nname: my-lib\nversion: 1.0.0.0\n"
+    writeFile (pkgDir </> "CHANGELOG.md") "## 1.0.0.0\n\n- Initial\n"
+    Yaml.encodeFile
+      (tmpDir </> ".changes" </> "10-old-fix.yml")
+      Fragment
+        { fragmentProject = "my-lib"
+        , fragmentKinds = ["bugfix"]
+        , fragmentDescription = "Old fix from a previous cycle"
+        , fragmentPR = 10
+        }
+    commitAll tmpDir "initial with pre-existing fragment"
+    withFeatureBranch tmpDir $ do
+      writeFile (tmpDir </> "my-lib" </> "Lib.hs") "module Lib where\n"
+      commitAll tmpDir "modify lib without new fragment"
+      validateDiff testConfigDiffRepo tmpDir
+
+  shouldFail errors
+  H.assert $ any (T.isInfixOf "my-lib") errors
+
+-- | A new fragment that names a different project does not satisfy the modified project.
+prop_validate_diff_wrong_project :: Property
+prop_validate_diff_wrong_project = H.propertyOnce $ do
+  errors <- H.evalIO $ setupMultiDiffRepo $ \tmpDir -> do
+    writeFile (tmpDir </> "lib-a" </> "Foo.hs") "module Foo where\n"
+    Yaml.encodeFile
+      (tmpDir </> ".changes" </> "123-lib-b-fix.yml")
+      Fragment
+        { fragmentProject = "lib-b"
+        , fragmentKinds = ["bugfix"]
+        , fragmentDescription = "Fix for lib-b"
+        , fragmentPR = 123
+        }
+    commitAll tmpDir "modify lib-a, add fragment for lib-b"
+    validateDiff testConfigMultiDiffRepo tmpDir
+
+  shouldFail errors
+  H.assert $ any (T.isInfixOf "lib-a") errors
+  H.assert . not $ any (T.isInfixOf "lib-b") errors
+
+-- | A malformed YAML file in .changes/ does not count as a valid fragment.
+prop_validate_diff_malformed_fragment :: Property
+prop_validate_diff_malformed_fragment = H.propertyOnce $ do
+  errors <- H.evalIO $ setupDiffRepo $ \tmpDir -> do
+    writeFile (tmpDir </> "my-lib" </> "Lib.hs") "module Lib where\n"
+    writeFile (tmpDir </> ".changes" </> "123-broken.yml") "not: valid: yaml: [unterminated"
+    commitAll tmpDir "modify lib with broken fragment"
+    validateDiff testConfigDiffRepo tmpDir
+
+  shouldFail errors
+  H.assert $ any (T.isInfixOf "my-lib") errors
+
+-- | Both projects modified but only one has a fragment: only the uncovered one is flagged.
+prop_validate_diff_multi_partial :: Property
+prop_validate_diff_multi_partial = H.propertyOnce $ do
+  errors <- H.evalIO $ setupMultiDiffRepo $ \tmpDir -> do
+    writeFile (tmpDir </> "lib-a" </> "Foo.hs") "module Foo where\n"
+    writeFile (tmpDir </> "lib-b" </> "Bar.hs") "module Bar where\n"
+    Yaml.encodeFile
+      (tmpDir </> ".changes" </> "123-lib-a-feature.yml")
+      Fragment
+        { fragmentProject = "lib-a"
+        , fragmentKinds = ["feature"]
+        , fragmentDescription = "New feature in lib-a"
+        , fragmentPR = 123
+        }
+    commitAll tmpDir "modify both, fragment only for lib-a"
+    validateDiff testConfigMultiDiffRepo tmpDir
+
+  shouldFail errors
+  H.assert . not $ any (T.isInfixOf "lib-a") errors
+  H.assert $ any (T.isInfixOf "lib-b") errors
+
+-- | A fragment with correct project but invalid kinds still satisfies validateDiff.
+-- validateDiff only checks project-name presence, not fragment validity.
+prop_validate_diff_invalid_content_satisfies :: Property
+prop_validate_diff_invalid_content_satisfies = H.propertyOnce $ do
+  errors <- H.evalIO $ setupDiffRepo $ \tmpDir -> do
+    writeFile (tmpDir </> "my-lib" </> "Lib.hs") "module Lib where\n"
+    Yaml.encodeFile
+      (tmpDir </> ".changes" </> "123-bad-kinds.yml")
+      Fragment
+        { fragmentProject = "my-lib"
+        , fragmentKinds = ["nonexistent-kind"]
+        , fragmentDescription = ""
+        , fragmentPR = -1
+        }
+    commitAll tmpDir "modify lib with invalid fragment"
+    validateDiff testConfigDiffRepo tmpDir
+
+  -- validateDiff passes because it only checks project name, not validity
+  shouldPass errors
+
+-- | When the feature branch has no commits beyond main, --diff passes (nothing changed).
+prop_validate_diff_no_commits :: Property
+prop_validate_diff_no_commits = H.propertyOnce $ do
+  errors <- H.evalIO $ setupDiffRepo $ \tmpDir ->
+    validateDiff testConfigDiffRepo tmpDir
+
+  shouldPass errors
+
+-- | Deleting a project file (without adding a fragment) triggers a diff error.
+prop_validate_diff_deleted :: Property
+prop_validate_diff_deleted = H.propertyOnce $ do
+  errors <- H.evalIO $ setupDiffRepo $ \tmpDir -> do
+    git tmpDir ["rm", "my-lib/my-lib.cabal"]
+    commitAll tmpDir "delete cabal file"
+    validateDiff testConfigDiffRepo tmpDir
+
+  shouldFail errors
+  H.assert $ any (T.isInfixOf "my-lib") errors
+
+-- | When no new fragments appear in the diff, --pr validation passes (nothing to check).
+prop_validate_pr_no_new_fragments :: Property
+prop_validate_pr_no_new_fragments = H.propertyOnce $ do
+  errors <- H.evalIO $ setupDiffRepo $ \tmpDir ->
+    validatePR testConfigDiffRepo tmpDir 42
+
+  shouldPass errors
+
+-- | A malformed YAML fragment in the diff produces a parse error from --pr validation.
+prop_validate_pr_malformed :: Property
+prop_validate_pr_malformed = H.propertyOnce $ do
+  errors <- H.evalIO $ setupDiffRepo $ \tmpDir -> do
+    writeFile
+      (tmpDir </> ".changes" </> "77-broken.yml")
+      "not: valid: yaml: [unterminated"
+    commitAll tmpDir "add broken fragment"
+    validatePR testConfigDiffRepo tmpDir 77
+
+  shouldFail errors
+
+-- | A fragment with matching PR but invalid content (unknown kind, empty description)
+-- passes validatePR, which only checks PR numbers, not fragment validity.
+prop_validate_pr_invalid_content_passes :: Property
+prop_validate_pr_invalid_content_passes = H.propertyOnce $ do
+  errors <- H.evalIO $ setupDiffRepo $ \tmpDir -> do
+    Yaml.encodeFile
+      (tmpDir </> ".changes" </> "42-bad-content.yml")
+      Fragment
+        { fragmentProject = "my-lib"
+        , fragmentKinds = ["nonexistent-kind"]
+        , fragmentDescription = ""
+        , fragmentPR = 42
+        }
+    commitAll tmpDir "add invalid fragment with correct PR"
+    validatePR testConfigDiffRepo tmpDir 42
+
+  -- PR matches, so validatePR passes despite invalid content
+  shouldPass errors
+
+-- | Validating a nonexistent file path produces a clean error.
+prop_validate_files_nonexistent :: Property
+prop_validate_files_nonexistent = H.propertyOnce $ do
+  errors <-
+    H.evalIO $
+      validateFiles testConfigDiffRepo ["/tmp/does-not-exist-12345.yml"]
+
+  shouldFail errors

--- a/herald/test-lib/Test/Herald/Assertions.hs
+++ b/herald/test-lib/Test/Herald/Assertions.hs
@@ -1,0 +1,47 @@
+-- | Hedgehog assertion helpers with informative failure messages.
+module Test.Herald.Assertions
+  ( shouldContain
+  , shouldNotContain
+  , shouldFail
+  , shouldPass
+  , shouldSatisfy
+  )
+where
+
+import Data.Text (Text)
+import Data.Text qualified as T
+
+import Hedgehog (MonadTest, (===))
+import Hedgehog qualified as H
+
+-- | Assert that @haystack@ contains @needle@ as a substring.
+-- On failure, shows both the expected needle and actual text.
+shouldContain :: MonadTest m => Text -> Text -> m ()
+shouldContain haystack needle = do
+  H.annotate $ "Expected to contain: " <> T.unpack needle
+  H.annotate $ "Actual:\n" <> T.unpack haystack
+  H.assert $ T.isInfixOf needle haystack
+
+-- | Assert that @haystack@ does NOT contain @needle@ as a substring.
+shouldNotContain :: MonadTest m => Text -> Text -> m ()
+shouldNotContain haystack needle = do
+  H.annotate $ "Expected NOT to contain: " <> T.unpack needle
+  H.annotate $ "Actual:\n" <> T.unpack haystack
+  H.assert . not $ T.isInfixOf needle haystack
+
+-- | Assert that a list of errors is non-empty (i.e. validation failed as expected).
+shouldFail :: (MonadTest m, Show a) => [a] -> m ()
+shouldFail xs = do
+  H.annotate $ "Expected non-empty error list, got: " <> show xs
+  H.assert . not $ null xs
+
+-- | Assert that a list of errors is empty (i.e. validation passed).
+-- Uses '===' so Hedgehog shows the diff on failure.
+shouldPass :: (MonadTest m, Show a, Eq a) => [a] -> m ()
+shouldPass xs = xs === []
+
+-- | Assert that a predicate holds, with a custom annotation.
+shouldSatisfy :: (MonadTest m, Show a) => a -> (a -> Bool) -> m ()
+shouldSatisfy x p = do
+  H.annotate $ "Value: " <> show x
+  H.assert $ p x

--- a/herald/test-lib/Test/Herald/Fixtures.hs
+++ b/herald/test-lib/Test/Herald/Fixtures.hs
@@ -1,0 +1,89 @@
+-- | Shared test data for Herald test suites.
+module Test.Herald.Fixtures
+  ( -- * PVP helpers
+    pvp
+  , breakingBump
+  , featureBump
+  , patchBump
+  , noBump
+
+    -- * Shared fixtures
+  , testKinds
+  , testDay
+  , testVersion
+  , testConfig
+  , testConfigMultiProject
+  )
+where
+
+import Data.List.NonEmpty (NonEmpty (..))
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Text (Text)
+import Data.Time (Day, fromGregorian)
+
+import Herald.Pvp (Pvp (..))
+import Herald.Types (Config (..), KindDef (..), ProjectConfig (..))
+
+-- | Construct a four-component PVP version.
+pvp :: Int -> Int -> Int -> Int -> Pvp
+pvp a b c d = Pvp (a :| [b, c, d])
+
+-- | Bump the second digit (A.B.0.0) -- breaking change.
+breakingBump :: Pvp
+breakingBump = pvp 0 1 0 0
+
+-- | Bump the third digit (A.B.C.0) -- new feature / compatible change.
+featureBump :: Pvp
+featureBump = pvp 0 0 1 0
+
+-- | Bump the fourth digit (A.B.C.D) -- bugfix / patch.
+patchBump :: Pvp
+patchBump = pvp 0 0 0 1
+
+-- | All-zero bump level -- identity (no version change).
+noBump :: Pvp
+noBump = pvp 0 0 0 0
+
+-- | Standard set of kinds used across tests.
+testKinds :: Map Text KindDef
+testKinds =
+  Map.fromList
+    [ ("breaking", KindDef True breakingBump (Just "the API has changed in a breaking way"))
+    , ("feature", KindDef True featureBump (Just "introduces a new feature"))
+    , ("bugfix", KindDef True patchBump (Just "fixes a defect"))
+    , ("refactoring", KindDef False patchBump Nothing)
+    , ("test", KindDef False patchBump Nothing)
+    ]
+
+testDay :: Day
+testDay = fromGregorian 2026 3 25
+
+testVersion :: Pvp
+testVersion = pvp 8 5 0 0
+
+-- | Config with a single project (cardano-api).
+testConfig :: Config
+testConfig =
+  Config
+    { configGitRepo = "https://github.com/IntersectMBO/cardano-api"
+    , configChangesDir = ".changes"
+    , configKinds = testKinds
+    , configProjects =
+        Map.fromList
+          [("cardano-api", ProjectConfig "cardano-api/CHANGELOG.md" (Just "cardano-api/cardano-api.cabal"))]
+    }
+
+-- | Config with two projects (for e2e / batch tests).
+testConfigMultiProject :: Config
+testConfigMultiProject =
+  testConfig
+    { configProjects =
+        Map.fromList
+          [ ("cardano-api", ProjectConfig "cardano-api/CHANGELOG.md" (Just "cardano-api/cardano-api.cabal"))
+          ,
+            ( "cardano-api-gen"
+            , ProjectConfig "cardano-api-gen/CHANGELOG.md" (Just "cardano-api-gen/cardano-api-gen.cabal")
+            )
+          ]
+    }

--- a/herald/test/Main.hs
+++ b/herald/test/Main.hs
@@ -1,0 +1,26 @@
+module Main where
+
+import Test.Herald.Cabal qualified as Cabal
+import Test.Herald.Changelog qualified as Changelog
+import Test.Herald.Config qualified as Config
+import Test.Herald.Fragment qualified as Fragment
+import Test.Herald.Git qualified as Git
+import Test.Herald.Pvp qualified as Pvp
+import Test.Herald.Render qualified as Render
+import Test.Herald.Terminal qualified as Terminal
+import Test.Tasty (defaultMain, testGroup)
+
+main :: IO ()
+main =
+  defaultMain $
+    testGroup
+      "herald"
+      [ Pvp.tests
+      , Fragment.tests
+      , Config.tests
+      , Render.tests
+      , Cabal.tests
+      , Changelog.tests
+      , Git.tests
+      , Terminal.tests
+      ]

--- a/herald/test/Test/Herald/Cabal.hs
+++ b/herald/test/Test/Herald/Cabal.hs
@@ -1,0 +1,101 @@
+module Test.Herald.Cabal (tests) where
+
+import Data.Text qualified as T
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
+
+import Hedgehog (Property, (===))
+import Hedgehog qualified as H
+import Hedgehog.Extras qualified as H
+import Test.Herald.Assertions (shouldContain)
+import Test.Herald.Fixtures (pvp)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Hedgehog (testProperty)
+
+import Herald.Cabal (readCabalVersion, writeCabalVersion)
+
+tests :: TestTree
+tests =
+  testGroup
+    "Herald.Cabal"
+    [ testProperty "read version from .cabal" prop_read_version
+    , testProperty "read version with spaces" prop_read_version_spaces
+    , testProperty "no version line returns Nothing" prop_read_no_version
+    , testProperty "write version preserves file" prop_write_preserves
+    , testProperty "write then read roundtrip" prop_write_read_roundtrip
+    ]
+
+sampleCabal :: String
+sampleCabal =
+  unlines
+    [ "cabal-version: 3.0"
+    , "name:          cardano-api"
+    , "version:       8.4.1.2"
+    , "synopsis:      Test package"
+    , ""
+    , "library"
+    , "  build-depends: base"
+    ]
+
+sampleCabalSpaces :: String
+sampleCabalSpaces =
+  unlines
+    [ "cabal-version: 3.0"
+    , "name:          cardano-api"
+    , "version:        8.4.1.2"
+    , "synopsis:      Test package"
+    ]
+
+-- | A .cabal file without a version: line returns Nothing.
+prop_read_no_version :: Property
+prop_read_no_version = H.propertyOnce $ do
+  result <- H.evalIO $ withSystemTempDirectory "herald-test" $ \tmpDir -> do
+    let cabalFile = tmpDir </> "test.cabal"
+    writeFile cabalFile $ unlines ["cabal-version: 3.0", "name: test-pkg", "synopsis: No version"]
+    readCabalVersion cabalFile
+  result === Nothing
+
+-- | Extracts the version from a standard .cabal file.
+prop_read_version :: Property
+prop_read_version = H.propertyOnce $ do
+  result <- H.evalIO $ withSystemTempDirectory "herald-test" $ \tmpDir -> do
+    let cabalFile = tmpDir </> "test.cabal"
+    writeFile cabalFile sampleCabal
+    readCabalVersion cabalFile
+  result === Just (pvp 8 4 1 2)
+
+-- | Extra whitespace around the version value is tolerated.
+prop_read_version_spaces :: Property
+prop_read_version_spaces = H.propertyOnce $ do
+  result <- H.evalIO $ withSystemTempDirectory "herald-test" $ \tmpDir -> do
+    let cabalFile = tmpDir </> "test.cabal"
+    writeFile cabalFile sampleCabalSpaces
+    readCabalVersion cabalFile
+  result === Just (pvp 8 4 1 2)
+
+-- | Writing a new version updates the version: line but preserves all other content.
+prop_write_preserves :: Property
+prop_write_preserves = H.propertyOnce $ do
+  content <- H.evalIO $ withSystemTempDirectory "herald-test" $ \tmpDir -> do
+    let cabalFile = tmpDir </> "test.cabal"
+    writeFile cabalFile sampleCabal
+    writeCabalVersion cabalFile (pvp 9 0 0 0)
+    T.pack <$> readFile cabalFile
+  content `shouldContain` "version:"
+  content `shouldContain` "9.0.0.0"
+  content `shouldContain` "name:          cardano-api"
+  content `shouldContain` "synopsis:      Test package"
+  content `shouldContain` "build-depends: base"
+
+-- | write followed by read recovers the written version.
+prop_write_read_roundtrip :: Property
+prop_write_read_roundtrip = H.propertyOnce $ do
+  result <- H.evalIO $ withSystemTmpDirectory "herald-test" $ \tmpDir -> do
+    let cabalFile = tmpDir </> "test.cabal"
+    writeFile cabalFile sampleCabal
+    writeCabalVersion cabalFile (pvp 9 0 0 0)
+    readCabalVersion cabalFile
+  result === Just (pvp 9 0 0 0)
+ where
+  -- withSystemTmpDirectory is just an alias for clarity in this context
+  withSystemTmpDirectory = withSystemTempDirectory

--- a/herald/test/Test/Herald/Changelog.hs
+++ b/herald/test/Test/Herald/Changelog.hs
@@ -1,0 +1,65 @@
+module Test.Herald.Changelog (tests) where
+
+import Data.Text qualified as T
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
+
+import Hedgehog (Property)
+import Hedgehog qualified as H
+import Hedgehog.Extras qualified as H
+import Test.Herald.Assertions (shouldContain)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Hedgehog (testProperty)
+
+import Herald.Changelog (prependSection)
+
+tests :: TestTree
+tests =
+  testGroup
+    "Herald.Changelog"
+    [ testProperty "prepend before existing ## header" prop_prepend_before_header
+    , testProperty "no ## header appends at end" prop_no_header_appends
+    , testProperty "preamble before ## is preserved" prop_preamble_preserved
+    ]
+
+-- | Section is inserted before the first ## header.
+prop_prepend_before_header :: Property
+prop_prepend_before_header = H.propertyOnce $ do
+  content <- H.evalIO $ withSystemTempDirectory "herald-changelog" $ \tmpDir -> do
+    let path = tmpDir </> "CHANGELOG.md"
+    writeFile path "## 1.0.0.0\n\n- Old entry\n"
+    prependSection path "## 2.0.0.0 -- 2026-04-01\n\n- New entry\n"
+    T.pack <$> readFile path
+  let idxNew = T.length . fst $ T.breakOn "## 2.0.0.0" content
+      idxOld = T.length . fst $ T.breakOn "## 1.0.0.0" content
+  H.assert $ idxNew < idxOld
+  content `shouldContain` "Old entry"
+  content `shouldContain` "New entry"
+
+-- | When the file has no ## header, the section is appended at the end.
+prop_no_header_appends :: Property
+prop_no_header_appends = H.propertyOnce $ do
+  content <- H.evalIO $ withSystemTempDirectory "herald-changelog" $ \tmpDir -> do
+    let path = tmpDir </> "CHANGELOG.md"
+    writeFile path "# My Project Changelog\n\nSome introductory text.\n"
+    prependSection path "## 1.0.0.0 -- 2026-04-01\n\n- First release\n"
+    T.pack <$> readFile path
+  content `shouldContain` "# My Project Changelog"
+  content `shouldContain` "Some introductory text."
+  content `shouldContain` "## 1.0.0.0"
+  content `shouldContain` "First release"
+
+-- | Preamble text before the first ## header is preserved above the new section.
+prop_preamble_preserved :: Property
+prop_preamble_preserved = H.propertyOnce $ do
+  content <- H.evalIO $ withSystemTempDirectory "herald-changelog" $ \tmpDir -> do
+    let path = tmpDir </> "CHANGELOG.md"
+    writeFile path "# Changelog\n\n## 1.0.0.0\n\n- Old entry\n"
+    prependSection path "## 2.0.0.0 -- 2026-04-01\n\n- New entry\n"
+    T.pack <$> readFile path
+  -- Preamble should come first, then new section, then old section
+  let idxPreamble = T.length . fst $ T.breakOn "# Changelog" content
+      idxNew = T.length . fst $ T.breakOn "## 2.0.0.0" content
+      idxOld = T.length . fst $ T.breakOn "## 1.0.0.0" content
+  H.assert $ idxPreamble < idxNew
+  H.assert $ idxNew < idxOld

--- a/herald/test/Test/Herald/Config.hs
+++ b/herald/test/Test/Herald/Config.hs
@@ -1,0 +1,112 @@
+module Test.Herald.Config (tests) where
+
+import Data.ByteString (isInfixOf)
+import Data.Text.Encoding (encodeUtf8)
+import Data.Yaml (decodeEither', encode)
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
+
+import Hedgehog (Property, (===))
+import Hedgehog qualified as H
+import Hedgehog.Extras qualified as H
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Hedgehog (testProperty)
+
+import Herald.Config (loadConfig)
+import Herald.Types (KindDef (..))
+
+tests :: TestTree
+tests =
+  testGroup
+    "Herald.Config"
+    [ testGroup
+        "KindDef parsing"
+        [ testProperty "notable defaults to true when omitted" prop_notable_default
+        , testProperty "notable false is parsed" prop_notable_false
+        , testProperty "description is parsed when present" prop_description_present
+        , testProperty "description is absent when omitted" prop_description_absent
+        ]
+    , testGroup
+        "Config loading"
+        [ testProperty "missing required fields produces parse error" prop_load_missing_fields
+        ]
+    , testGroup
+        "KindDef serialization"
+        [ testProperty "notable true is omitted from output" prop_serialize_notable_true
+        , testProperty "notable false is present in output" prop_serialize_notable_false
+        , testProperty "description is omitted when Nothing" prop_serialize_no_description
+        , testProperty "description is present when Just" prop_serialize_with_description
+        ]
+    ]
+
+-- | When 'notable' is absent from YAML, it defaults to True.
+prop_notable_default :: Property
+prop_notable_default = H.propertyOnce $ do
+  kd <- H.leftFail . decodeEither' . encodeUtf8 $ "bump: 0.0.0.1\n"
+  kindNotable kd === True
+
+-- | Explicit 'notable: false' is parsed correctly.
+prop_notable_false :: Property
+prop_notable_false = H.propertyOnce $ do
+  kd <- H.leftFail . decodeEither' . encodeUtf8 $ "notable: false\nbump: 0.0.0.1\n"
+  kindNotable kd === False
+
+-- | The 'description' field is parsed when present.
+prop_description_present :: Property
+prop_description_present = H.propertyOnce $ do
+  kd <- H.leftFail . decodeEither' . encodeUtf8 $ "bump: 0.0.0.1\ndescription: fixes a defect\n"
+  kindDescription kd === Just "fixes a defect"
+
+-- | The 'description' field is Nothing when omitted.
+prop_description_absent :: Property
+prop_description_absent = H.propertyOnce $ do
+  kd <- H.leftFail . decodeEither' . encodeUtf8 $ "bump: 0.0.0.1\n"
+  kindDescription kd === Nothing
+
+-- | When notable is True (default), the key is omitted from serialized output.
+prop_serialize_notable_true :: Property
+prop_serialize_notable_true = H.propertyOnce $ do
+  kd <- H.leftFail . decodeEither' . encodeUtf8 $ "bump: 0.1.0.0\n"
+  let output = encode (kd :: KindDef)
+  H.assert . not $ isInfixOf "notable" output
+  -- Roundtrip preserves the value
+  kd2 <- H.leftFail $ decodeEither' output
+  kindNotable kd2 === True
+  kindBump kd === kindBump kd2
+
+-- | When notable is False, it appears in serialized output.
+prop_serialize_notable_false :: Property
+prop_serialize_notable_false = H.propertyOnce $ do
+  kd <- H.leftFail . decodeEither' . encodeUtf8 $ "notable: false\nbump: 0.0.1.0\n"
+  let output = encode (kd :: KindDef)
+  kd2 <- H.leftFail $ decodeEither' output
+  kindNotable kd2 === False
+
+-- | description: Nothing roundtrips correctly (key omitted).
+prop_serialize_no_description :: Property
+prop_serialize_no_description = H.propertyOnce $ do
+  kd <- H.leftFail . decodeEither' . encodeUtf8 $ "bump: 0.0.0.1\n"
+  let output = encode (kd :: KindDef)
+  kd2 <- H.leftFail $ decodeEither' output
+  kindDescription kd2 === Nothing
+
+-- | description: Just roundtrips correctly.
+prop_serialize_with_description :: Property
+prop_serialize_with_description = H.propertyOnce $ do
+  kd <- H.leftFail . decodeEither' . encodeUtf8 $ "bump: 0.0.0.1\ndescription: fixes a defect\n"
+  let output = encode (kd :: KindDef)
+  kd2 <- H.leftFail $ decodeEither' output
+  kindDescription kd2 === Just "fixes a defect"
+
+-- | A YAML config with missing required fields returns Left.
+prop_load_missing_fields :: Property
+prop_load_missing_fields = H.propertyOnce $ do
+  result <- H.evalIO $ withSystemTempDirectory "herald-config" $ \tmpDir -> do
+    let configPath = tmpDir </> ".herald.yml"
+    -- Missing 'projects' and 'kinds' fields
+    writeFile configPath "git-repo: test/repo\nchanges-dir: .changes\n"
+    loadConfig configPath
+
+  case result of
+    Left _ -> H.success
+    Right _ -> H.failure

--- a/herald/test/Test/Herald/Fragment.hs
+++ b/herald/test/Test/Herald/Fragment.hs
@@ -1,0 +1,261 @@
+module Test.Herald.Fragment (tests) where
+
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Text.Encoding (encodeUtf8)
+import Data.Yaml (decodeEither')
+
+import Hedgehog (Property, (===))
+import Hedgehog qualified as H
+import Hedgehog.Extras qualified as H
+import Test.Herald.Assertions (shouldFail, shouldPass)
+import Test.Herald.Fixtures (testConfig)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Hedgehog (testProperty)
+
+import Herald.Fragment (validateFragment)
+import Herald.Types (Fragment (..))
+
+tests :: TestTree
+tests =
+  testGroup
+    "Herald.Fragment"
+    [ testGroup
+        "YAML parsing"
+        [ testProperty "parse valid fragment" prop_parse_valid
+        , testProperty "parse fragment with multiple kinds" prop_parse_multi_kinds
+        , testProperty "reject missing project" prop_reject_missing_project
+        , testProperty "reject missing pr" prop_reject_missing_pr
+        , testProperty "reject missing kind" prop_reject_missing_kind
+        , testProperty "reject missing description" prop_reject_missing_description
+        ]
+    , testGroup
+        "validateFragment"
+        [ testProperty "valid fragment" prop_validate_valid
+        , testProperty "unknown kind" prop_validate_unknown_kind
+        , testProperty "unknown project" prop_validate_unknown_project
+        , testProperty "empty description" prop_validate_empty_description
+        , testProperty "whitespace-only description" prop_validate_whitespace_description
+        , testProperty "PR <= 0" prop_validate_bad_pr
+        , testProperty "negative PR" prop_validate_negative_pr
+        , testProperty "empty kinds list" prop_validate_empty_kinds
+        , testProperty "extra YAML fields are silently ignored" prop_parse_extra_fields
+        ]
+    ]
+
+-- | Helper to build YAML ByteStrings readably.
+yaml :: [Text] -> T.Text
+yaml = T.unlines
+
+-- YAML parsing tests
+
+-- | A well-formed fragment YAML is decoded with all fields intact.
+prop_parse_valid :: Property
+prop_parse_valid = H.propertyOnce $ do
+  let input =
+        encodeUtf8 $
+          yaml
+            [ "project: cardano-api"
+            , "kind:"
+            , "  - bugfix"
+            , "description: Fix serialization"
+            , "pr: 42"
+            ]
+  frag <- H.leftFail $ decodeEither' input
+  fragmentProject frag === "cardano-api"
+  fragmentKinds frag === ["bugfix"]
+  fragmentDescription frag === "Fix serialization"
+  fragmentPR frag === 42
+
+-- | Multiple kinds in a fragment are parsed as a list.
+prop_parse_multi_kinds :: Property
+prop_parse_multi_kinds = H.propertyOnce $ do
+  let input =
+        encodeUtf8 $
+          yaml
+            [ "project: cardano-api"
+            , "kind:"
+            , "  - bugfix"
+            , "  - refactoring"
+            , "description: Fix and refactor"
+            , "pr: 99"
+            ]
+  frag <- H.leftFail $ decodeEither' input
+  fragmentKinds frag === ["bugfix", "refactoring"]
+
+-- | Missing 'project' field causes a parse error.
+prop_reject_missing_project :: Property
+prop_reject_missing_project = H.propertyOnce $ do
+  let input =
+        encodeUtf8 $
+          yaml
+            [ "kind:"
+            , "  - bugfix"
+            , "description: Fix something"
+            , "pr: 42"
+            ]
+  case decodeEither' input of
+    Left _ -> H.success
+    Right (_ :: Fragment) -> H.failure
+
+-- | Missing 'pr' field causes a parse error.
+prop_reject_missing_pr :: Property
+prop_reject_missing_pr = H.propertyOnce $ do
+  let input =
+        encodeUtf8 $
+          yaml
+            [ "project: cardano-api"
+            , "kind:"
+            , "  - bugfix"
+            , "description: Fix something"
+            ]
+  case decodeEither' input of
+    Left _ -> H.success
+    Right (_ :: Fragment) -> H.failure
+
+-- | Missing 'kind' field causes a parse error.
+prop_reject_missing_kind :: Property
+prop_reject_missing_kind = H.propertyOnce $ do
+  let input =
+        encodeUtf8 $
+          yaml
+            [ "project: cardano-api"
+            , "description: Fix something"
+            , "pr: 42"
+            ]
+  case decodeEither' input of
+    Left _ -> H.success
+    Right (_ :: Fragment) -> H.failure
+
+-- | Missing 'description' field causes a parse error.
+prop_reject_missing_description :: Property
+prop_reject_missing_description = H.propertyOnce $ do
+  let input =
+        encodeUtf8 $
+          yaml
+            [ "project: cardano-api"
+            , "kind:"
+            , "  - bugfix"
+            , "pr: 42"
+            ]
+  case decodeEither' input of
+    Left _ -> H.success
+    Right (_ :: Fragment) -> H.failure
+
+-- validateFragment tests
+
+-- | A fragment with known project, known kinds, non-empty description, and positive PR passes.
+prop_validate_valid :: Property
+prop_validate_valid = H.propertyOnce $ do
+  let frag =
+        Fragment
+          { fragmentProject = "cardano-api"
+          , fragmentKinds = ["bugfix"]
+          , fragmentDescription = "Fix serialization"
+          , fragmentPR = 42
+          }
+  shouldPass $ validateFragment testConfig frag
+
+-- | A fragment referencing a kind not in the config is rejected.
+prop_validate_unknown_kind :: Property
+prop_validate_unknown_kind = H.propertyOnce $ do
+  let frag =
+        Fragment
+          { fragmentProject = "cardano-api"
+          , fragmentKinds = ["nonexistent-kind"]
+          , fragmentDescription = "Fix something"
+          , fragmentPR = 42
+          }
+  shouldFail $ validateFragment testConfig frag
+
+-- | A fragment referencing a project not in the config is rejected.
+prop_validate_unknown_project :: Property
+prop_validate_unknown_project = H.propertyOnce $ do
+  let frag =
+        Fragment
+          { fragmentProject = "nonexistent-project"
+          , fragmentKinds = ["bugfix"]
+          , fragmentDescription = "Fix something"
+          , fragmentPR = 42
+          }
+  shouldFail $ validateFragment testConfig frag
+
+-- | An empty description is rejected.
+prop_validate_empty_description :: Property
+prop_validate_empty_description = H.propertyOnce $ do
+  let frag =
+        Fragment
+          { fragmentProject = "cardano-api"
+          , fragmentKinds = ["bugfix"]
+          , fragmentDescription = ""
+          , fragmentPR = 42
+          }
+  shouldFail $ validateFragment testConfig frag
+
+-- | PR number <= 0 is rejected.
+prop_validate_bad_pr :: Property
+prop_validate_bad_pr = H.propertyOnce $ do
+  let frag =
+        Fragment
+          { fragmentProject = "cardano-api"
+          , fragmentKinds = ["bugfix"]
+          , fragmentDescription = "Fix something"
+          , fragmentPR = 0
+          }
+  shouldFail $ validateFragment testConfig frag
+
+-- | Whitespace-only description is rejected (strip then check empty).
+prop_validate_whitespace_description :: Property
+prop_validate_whitespace_description = H.propertyOnce $ do
+  let frag =
+        Fragment
+          { fragmentProject = "cardano-api"
+          , fragmentKinds = ["bugfix"]
+          , fragmentDescription = "   \t  "
+          , fragmentPR = 42
+          }
+  shouldFail $ validateFragment testConfig frag
+
+-- | Negative PR number is rejected (not just zero).
+prop_validate_negative_pr :: Property
+prop_validate_negative_pr = H.propertyOnce $ do
+  let frag =
+        Fragment
+          { fragmentProject = "cardano-api"
+          , fragmentKinds = ["bugfix"]
+          , fragmentDescription = "Fix something"
+          , fragmentPR = -5
+          }
+  shouldFail $ validateFragment testConfig frag
+
+-- | An empty kinds list is rejected.
+prop_validate_empty_kinds :: Property
+prop_validate_empty_kinds = H.propertyOnce $ do
+  let frag =
+        Fragment
+          { fragmentProject = "cardano-api"
+          , fragmentKinds = []
+          , fragmentDescription = "Fix something"
+          , fragmentPR = 42
+          }
+  shouldFail $ validateFragment testConfig frag
+
+-- | Extra unknown YAML fields are silently ignored by the parser.
+prop_parse_extra_fields :: Property
+prop_parse_extra_fields = H.propertyOnce $ do
+  let input =
+        encodeUtf8 $
+          yaml
+            [ "project: cardano-api"
+            , "kind:"
+            , "  - bugfix"
+            , "description: Fix something"
+            , "pr: 42"
+            , "severity: critical"
+            , "author: someone"
+            ]
+  frag <- H.leftFail $ decodeEither' input
+  fragmentProject frag === "cardano-api"
+  fragmentKinds frag === ["bugfix"]
+  fragmentDescription frag === "Fix something"
+  fragmentPR frag === 42

--- a/herald/test/Test/Herald/Git.hs
+++ b/herald/test/Test/Herald/Git.hs
@@ -1,0 +1,228 @@
+module Test.Herald.Git (tests) where
+
+import Data.Text (Text)
+import Data.Text qualified as T
+
+import Hedgehog (Property, (===))
+import Hedgehog.Extras qualified as H
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Hedgehog (testProperty)
+
+import Herald.Git (normaliseGitRepo, parseRepoSlug)
+import Herald.Git.Repository (lookupGitConfig)
+
+tests :: TestTree
+tests =
+  testGroup
+    "Herald.Git"
+    [ testGroup
+        "parseRepoSlug"
+        [ testProperty "SSH URL" prop_slug_ssh
+        , testProperty "SSH URL without .git" prop_slug_ssh_no_git
+        , testProperty "HTTPS URL" prop_slug_https
+        , testProperty "HTTPS URL without .git" prop_slug_https_no_git
+        , testProperty "unrecognised URL returns Nothing" prop_slug_unknown
+        , testProperty "SSH without colon returns Nothing" prop_slug_ssh_no_colon
+        , testProperty "HTTPS with no path returns Nothing" prop_slug_https_no_path
+        , testProperty "SSH with slash instead of colon returns Nothing" prop_slug_ssh_slash
+        ]
+    , testGroup
+        "normaliseGitRepo"
+        [ testProperty "bare slug assumes GitHub" prop_normalise_bare_slug
+        , testProperty "HTTPS URL passes through" prop_normalise_https
+        , testProperty "SSH URL gets normalised" prop_normalise_ssh
+        , testProperty "trailing slash stripped" prop_normalise_trailing_slash
+        , testProperty "unrecognised text passes through" prop_normalise_unknown
+        ]
+    , testGroup
+        "lookupGitConfig"
+        [ testProperty "simple section.key" prop_simple_key
+        , testProperty "subsection key" prop_subsection_key
+        , testProperty "missing key" prop_missing_key
+        , testProperty "missing section" prop_missing_section
+        , testProperty "case insensitive section" prop_case_insensitive
+        , testProperty "subsection name is case sensitive" prop_subsection_case_sensitive
+        , testProperty "comment lines ignored" prop_comments_ignored
+        , testProperty "multiple sections" prop_multiple_sections
+        ]
+    ]
+
+-- | SSH git@host:owner/repo.git -> https://host/owner/repo
+prop_slug_ssh :: Property
+prop_slug_ssh =
+  H.propertyOnce $
+    parseRepoSlug "git@github.com:IntersectMBO/cardano-api.git"
+      === Just "https://github.com/IntersectMBO/cardano-api"
+
+-- | SSH without .git suffix
+prop_slug_ssh_no_git :: Property
+prop_slug_ssh_no_git =
+  H.propertyOnce $
+    parseRepoSlug "git@gitlab.com:myorg/myrepo"
+      === Just "https://gitlab.com/myorg/myrepo"
+
+-- | HTTPS https://host/owner/repo.git -> https://host/owner/repo
+prop_slug_https :: Property
+prop_slug_https =
+  H.propertyOnce $
+    parseRepoSlug "https://github.com/IntersectMBO/cardano-api.git"
+      === Just "https://github.com/IntersectMBO/cardano-api"
+
+-- | HTTPS without .git suffix
+prop_slug_https_no_git :: Property
+prop_slug_https_no_git =
+  H.propertyOnce $
+    parseRepoSlug "https://github.com/MyOrg/my-repo"
+      === Just "https://github.com/MyOrg/my-repo"
+
+-- | Unrecognised URL scheme returns Nothing
+prop_slug_unknown :: Property
+prop_slug_unknown =
+  H.propertyOnce $
+    parseRepoSlug "svn://example.com/repo" === Nothing
+
+-- | SSH URL without a colon (no host:path separator)
+prop_slug_ssh_no_colon :: Property
+prop_slug_ssh_no_colon =
+  H.propertyOnce $
+    parseRepoSlug "git@github.com" === Nothing
+
+-- | HTTPS URL with only a host and no owner/repo path
+prop_slug_https_no_path :: Property
+prop_slug_https_no_path =
+  H.propertyOnce $
+    parseRepoSlug "https://github.com" === Nothing
+
+-- | SSH-style URL with slash instead of colon (ssh:// form)
+prop_slug_ssh_slash :: Property
+prop_slug_ssh_slash =
+  H.propertyOnce $
+    parseRepoSlug "git@github.com/owner/repo.git" === Nothing
+
+-- normaliseGitRepo tests
+
+-- | Bare owner/repo slug is expanded to a GitHub HTTPS URL
+prop_normalise_bare_slug :: Property
+prop_normalise_bare_slug =
+  H.propertyOnce $
+    normaliseGitRepo "IntersectMBO/cardano-api"
+      === "https://github.com/IntersectMBO/cardano-api"
+
+-- | Full HTTPS URL passes through unchanged
+prop_normalise_https :: Property
+prop_normalise_https =
+  H.propertyOnce $
+    normaliseGitRepo "https://github.com/IntersectMBO/cardano-api"
+      === "https://github.com/IntersectMBO/cardano-api"
+
+-- | SSH URL is converted to HTTPS
+prop_normalise_ssh :: Property
+prop_normalise_ssh =
+  H.propertyOnce $
+    normaliseGitRepo "git@github.com:IntersectMBO/cardano-api.git"
+      === "https://github.com/IntersectMBO/cardano-api"
+
+-- | Trailing slash is stripped
+prop_normalise_trailing_slash :: Property
+prop_normalise_trailing_slash =
+  H.propertyOnce $
+    normaliseGitRepo "https://github.com/IntersectMBO/cardano-api/"
+      === "https://github.com/IntersectMBO/cardano-api"
+
+-- | Unrecognised text passes through unchanged
+prop_normalise_unknown :: Property
+prop_normalise_unknown =
+  H.propertyOnce $
+    normaliseGitRepo "just-a-word" === "just-a-word"
+
+sampleConfig :: Text
+sampleConfig =
+  T.unlines
+    [ "[core]"
+    , "\tbare = false"
+    , "\trepositoryformatversion = 0"
+    , "[remote \"origin\"]"
+    , "\turl = git@github.com:IntersectMBO/cardano-api.git"
+    , "\tfetch = +refs/heads/*:refs/remotes/origin/*"
+    , "[user]"
+    , "\temail = mateusz@iohk.io"
+    , "\tname = Mateusz Galazyn"
+    , "[github]"
+    , "\tuser = mgalazyn"
+    , "[scriv]"
+    , "\tuser-nick = mg"
+    , "# a comment line"
+    , "; another comment"
+    ]
+
+-- | Simple section.key lookups return the expected values.
+prop_simple_key :: Property
+prop_simple_key = H.propertyOnce $ do
+  lookupGitConfig "user.email" sampleConfig === Just "mateusz@iohk.io"
+  lookupGitConfig "github.user" sampleConfig === Just "mgalazyn"
+  lookupGitConfig "scriv.user-nick" sampleConfig === Just "mg"
+  lookupGitConfig "core.bare" sampleConfig === Just "false"
+
+-- | Subsection keys like remote.origin.url are resolved correctly.
+prop_subsection_key :: Property
+prop_subsection_key = H.propertyOnce $ do
+  lookupGitConfig "remote.origin.url" sampleConfig
+    === Just "git@github.com:IntersectMBO/cardano-api.git"
+  lookupGitConfig "remote.origin.fetch" sampleConfig
+    === Just "+refs/heads/*:refs/remotes/origin/*"
+
+-- | A key that doesn't exist in an existing section returns Nothing.
+prop_missing_key :: Property
+prop_missing_key = H.propertyOnce $ do
+  lookupGitConfig "user.nonexistent" sampleConfig === Nothing
+
+-- | A section that doesn't exist returns Nothing.
+prop_missing_section :: Property
+prop_missing_section = H.propertyOnce $ do
+  lookupGitConfig "nonexistent.key" sampleConfig === Nothing
+
+-- | Section and key lookups are case-insensitive.
+prop_case_insensitive :: Property
+prop_case_insensitive = H.propertyOnce $ do
+  lookupGitConfig "USER.EMAIL" sampleConfig === Just "mateusz@iohk.io"
+  lookupGitConfig "GitHub.User" sampleConfig === Just "mgalazyn"
+
+-- | Subsection names are case-sensitive per git specification.
+-- remote.Origin.url must NOT match [remote "origin"].
+prop_subsection_case_sensitive :: Property
+prop_subsection_case_sensitive = H.propertyOnce $ do
+  let config =
+        T.unlines
+          [ "[remote \"origin\"]"
+          , "\turl = git@github.com:test/repo.git"
+          ]
+  -- Exact case matches
+  lookupGitConfig "remote.origin.url" config === Just "git@github.com:test/repo.git"
+  -- Wrong case for subsection does NOT match
+  lookupGitConfig "remote.Origin.url" config === Nothing
+  lookupGitConfig "remote.ORIGIN.url" config === Nothing
+
+-- | Lines starting with # or ; are comments and are ignored.
+prop_comments_ignored :: Property
+prop_comments_ignored = H.propertyOnce $ do
+  let configWithComments =
+        T.unlines
+          [ "[test]"
+          , "# key = commented-out"
+          , "; key = also-commented"
+          , "\tkey = real-value"
+          ]
+  lookupGitConfig "test.key" configWithComments === Just "real-value"
+
+-- | Distinct subsections (e.g. two remotes) are resolved independently.
+prop_multiple_sections :: Property
+prop_multiple_sections = H.propertyOnce $ do
+  let config =
+        T.unlines
+          [ "[remote \"origin\"]"
+          , "\turl = origin-url"
+          , "[remote \"upstream\"]"
+          , "\turl = upstream-url"
+          ]
+  lookupGitConfig "remote.origin.url" config === Just "origin-url"
+  lookupGitConfig "remote.upstream.url" config === Just "upstream-url"

--- a/herald/test/Test/Herald/Pvp.hs
+++ b/herald/test/Test/Herald/Pvp.hs
@@ -1,0 +1,197 @@
+module Test.Herald.Pvp (tests) where
+
+import Data.List.NonEmpty (NonEmpty (..))
+
+import Hedgehog (Gen, Property, forAll, (===))
+import Hedgehog qualified as H
+import Hedgehog.Extras qualified as H
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
+import Test.Herald.Fixtures (breakingBump, featureBump, noBump, patchBump, pvp)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Hedgehog (testProperty)
+
+import Herald.Pvp (Pvp (..), bumpPvp, parsePvp, showPvp)
+
+tests :: TestTree
+tests =
+  testGroup
+    "Herald.Pvp"
+    [ testGroup
+        "parsePvp"
+        [ testProperty "roundtrip four parts" prop_roundtrip
+        , testProperty "single part" prop_single_part
+        , testProperty "three parts" prop_three_parts
+        , testProperty "five parts" prop_five_parts
+        , testProperty "rejects empty string" prop_rejects_empty
+        , testProperty "rejects non-digit" prop_rejects_non_digit
+        , testProperty "rejects negative" prop_rejects_negative
+        , testProperty "rejects trailing dot" prop_rejects_trailing_dot
+        , testProperty "rejects leading dot" prop_rejects_leading_dot
+        ]
+    , testGroup
+        "bumpPvp"
+        [ testProperty "bump 0.1.0.0 (second digit)" prop_bump_second
+        , testProperty "bump 0.0.1.0 (third digit)" prop_bump_third
+        , testProperty "bump 0.0.0.1 (fourth digit)" prop_bump_fourth
+        , testProperty "bump 0.0.0.0 (identity)" prop_bump_identity
+        ]
+    , testGroup
+        "bumpPvp short versions"
+        [ testProperty "bump second digit on two-part version" prop_bump_short_second
+        , testProperty "bump fourth digit on two-part version extends" prop_bump_short_fourth
+        , testProperty "bump first digit (A.0.0.0)" prop_bump_first
+        ]
+    , testGroup
+        "Pvp Ord"
+        [ testProperty "different-length versions compare lexicographically" prop_ord_different_length
+        ]
+    , testGroup
+        "parsePvp edge cases"
+        [ testProperty "leading zeros are silently stripped" prop_leading_zeros
+        ]
+    , testGroup
+        "properties"
+        [ testProperty "max bump level" prop_max_bump
+        , testProperty "parsePvp/showPvp roundtrip" prop_roundtrip_property
+        , testProperty "bumpPvp result >= input (monotonicity)" prop_bump_monotonic
+        ]
+    ]
+
+-- parsePvp tests
+
+-- | Parsing and showing a four-part version is a no-op.
+prop_roundtrip :: Property
+prop_roundtrip = H.propertyOnce $ do
+  fmap showPvp (parsePvp "8.4.1.2") === Just "8.4.1.2"
+  fmap showPvp (parsePvp "0.0.0.0") === Just "0.0.0.0"
+  fmap showPvp (parsePvp "99.0.12.3") === Just "99.0.12.3"
+
+-- | A bare integer is a valid single-component version.
+prop_single_part :: Property
+prop_single_part = H.propertyOnce $ do
+  fmap showPvp (parsePvp "42") === Just "42"
+
+-- | Three-part versions are accepted (not just four).
+prop_three_parts :: Property
+prop_three_parts = H.propertyOnce $ do
+  fmap showPvp (parsePvp "1.2.3") === Just "1.2.3"
+
+-- | Five-part versions are accepted (PVP allows any length).
+prop_five_parts :: Property
+prop_five_parts = H.propertyOnce $ do
+  fmap showPvp (parsePvp "1.2.3.4.5") === Just "1.2.3.4.5"
+
+-- | Empty string is not a valid version.
+prop_rejects_empty :: Property
+prop_rejects_empty = H.propertyOnce $ do
+  parsePvp "" === Nothing
+
+-- | Non-digit characters cause a parse failure.
+prop_rejects_non_digit :: Property
+prop_rejects_non_digit = H.propertyOnce $ do
+  parsePvp "1.2.3.a" === Nothing
+  parsePvp "x.2.3.4" === Nothing
+
+-- | Leading minus sign is rejected (components must be non-negative).
+prop_rejects_negative :: Property
+prop_rejects_negative = H.propertyOnce $ do
+  parsePvp "-1.2.3.4" === Nothing
+
+-- | A trailing dot leaves an empty final component.
+prop_rejects_trailing_dot :: Property
+prop_rejects_trailing_dot = H.propertyOnce $ do
+  parsePvp "1.2.3." === Nothing
+
+-- | A leading dot leaves an empty first component.
+prop_rejects_leading_dot :: Property
+prop_rejects_leading_dot = H.propertyOnce $ do
+  parsePvp ".1.2.3" === Nothing
+
+-- bumpPvp tests
+
+-- | Breaking bump (0.1.0.0): increments second digit, zeros the rest.
+prop_bump_second :: Property
+prop_bump_second = H.propertyOnce $ do
+  bumpPvp breakingBump (pvp 8 4 1 2) === pvp 8 5 0 0
+
+-- | Feature bump (0.0.1.0): increments third digit, zeros the rest.
+prop_bump_third :: Property
+prop_bump_third = H.propertyOnce $ do
+  bumpPvp featureBump (pvp 8 4 1 2) === pvp 8 4 2 0
+
+-- | Patch bump (0.0.0.1): increments fourth digit only.
+prop_bump_fourth :: Property
+prop_bump_fourth = H.propertyOnce $ do
+  bumpPvp patchBump (pvp 8 4 1 2) === pvp 8 4 1 3
+
+-- | All-zero bump level is the identity -- version unchanged.
+prop_bump_identity :: Property
+prop_bump_identity = H.propertyOnce $ do
+  bumpPvp noBump (pvp 8 4 1 2) === pvp 8 4 1 2
+
+-- | The maximum of several bump levels is the most significant one.
+prop_max_bump :: Property
+prop_max_bump = H.propertyOnce $ do
+  let bumps = [patchBump, breakingBump, featureBump]
+  maximum bumps === breakingBump
+
+-- | For any random PVP value, parse . show is the identity.
+prop_roundtrip_property :: Property
+prop_roundtrip_property = H.property $ do
+  v <- forAll genPvp
+  parsePvp (showPvp v) === Just v
+
+-- | Bumping the second digit of a two-part version works without four components.
+prop_bump_short_second :: Property
+prop_bump_short_second = H.propertyOnce $ do
+  bumpPvp breakingBump (Pvp (1 :| [0])) === Pvp (1 :| [1])
+
+-- | Bumping the fourth digit of a two-part version extends it to four components.
+prop_bump_short_fourth :: Property
+prop_bump_short_fourth = H.propertyOnce $ do
+  bumpPvp patchBump (Pvp (1 :| [0])) === pvp 1 0 0 1
+
+-- | Bumping the first digit increments A and zeros everything after.
+prop_bump_first :: Property
+prop_bump_first = H.propertyOnce $ do
+  let firstDigitBump = Pvp (1 :| [0, 0, 0])
+  bumpPvp firstDigitBump (pvp 8 4 1 2) === pvp 9 0 0 0
+
+-- | Different-length versions: 1.0 < 1.0.0.0 under derived Ord.
+-- This documents the current behaviour -- PVP considers them equivalent,
+-- but our Ord is lexicographic-then-length.
+prop_ord_different_length :: Property
+prop_ord_different_length = H.propertyOnce $ do
+  H.assert $ Pvp (1 :| [0]) < Pvp (1 :| [0, 0, 0])
+  H.assert $ Pvp (1 :| [0, 0, 0]) > Pvp (1 :| [0])
+  -- Same-length comparison still works normally
+  H.assert $ pvp 1 0 0 0 == pvp 1 0 0 0
+  H.assert $ pvp 1 0 0 1 > pvp 1 0 0 0
+
+-- | Leading zeros in version components are silently stripped by parsePvp.
+-- parsePvp "01.02.03" succeeds but showPvp gives "1.2.3".
+prop_leading_zeros :: Property
+prop_leading_zeros = H.propertyOnce $ do
+  fmap showPvp (parsePvp "01.02.03") === Just "1.2.3"
+  -- The parsed value equals the non-leading-zero version
+  parsePvp "01.02.03" === parsePvp "1.2.3"
+
+-- | For any random PVP and bump level, bumping never decreases the version.
+prop_bump_monotonic :: Property
+prop_bump_monotonic = H.property $ do
+  v <- forAll genPvp
+  bump <- forAll genBump
+  H.assert $ bumpPvp bump v >= v
+
+genBump :: Gen Pvp
+genBump =
+  Gen.element [noBump, patchBump, featureBump, breakingBump]
+
+genPvp :: Gen Pvp
+genPvp = do
+  len <- Gen.int (Range.linear 1 6)
+  cs <- Gen.list (Range.singleton len) (Gen.int (Range.linear 0 99))
+  case cs of
+    (c : rest) -> pure (Pvp (c :| rest))
+    [] -> pure (Pvp (0 :| []))

--- a/herald/test/Test/Herald/Render.hs
+++ b/herald/test/Test/Herald/Render.hs
@@ -1,0 +1,163 @@
+module Test.Herald.Render (tests) where
+
+import Data.Text qualified as T
+
+import Hedgehog (Property)
+import Hedgehog qualified as H
+import Hedgehog.Extras qualified as H
+import Test.Herald.Assertions (shouldContain, shouldNotContain)
+import Test.Herald.Fixtures (testConfig, testDay, testVersion)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Hedgehog (testProperty)
+
+import Herald.Fragment.Render (renderSection)
+import Herald.Types (Fragment (..))
+
+tests :: TestTree
+tests =
+  testGroup
+    "Herald.Fragment.Render"
+    [ testProperty "single notable fragment" prop_single_notable
+    , testProperty "multiple fragments sorted by PR" prop_sorted_by_pr
+    , testProperty "all non-notable excluded" prop_non_notable_excluded
+    , testProperty "mixed notable and non-notable" prop_mixed_notable
+    , testProperty "multi-line description" prop_multiline_description
+    , testProperty "empty fragment list" prop_empty_fragments
+    , testProperty "unknown kinds treated as non-notable" prop_unknown_kind_non_notable
+    , testProperty "duplicate PR numbers both rendered" prop_duplicate_pr
+    ]
+
+-- | A single notable fragment renders with version header, date, description, kind, and PR link.
+prop_single_notable :: Property
+prop_single_notable = H.propertyOnce $ do
+  let frags =
+        [ Fragment
+            { fragmentProject = "cardano-api"
+            , fragmentKinds = ["bugfix"]
+            , fragmentDescription = "Fix serialization of Conway certificates"
+            , fragmentPR = 42
+            }
+        ]
+      result = renderSection testConfig testVersion testDay frags
+  result `shouldContain` "## 8.5.0.0"
+  result `shouldContain` "2026-03-25"
+  result `shouldContain` "Fix serialization of Conway certificates"
+  result `shouldContain` "(bugfix)"
+  result `shouldContain` "PR 42"
+
+-- | Multiple fragments appear sorted by PR number (descending).
+prop_sorted_by_pr :: Property
+prop_sorted_by_pr = H.propertyOnce $ do
+  let frags =
+        [ Fragment
+            { fragmentProject = "cardano-api"
+            , fragmentKinds = ["bugfix"]
+            , fragmentDescription = "Second fix"
+            , fragmentPR = 42
+            }
+        , Fragment
+            { fragmentProject = "cardano-api"
+            , fragmentKinds = ["feature"]
+            , fragmentDescription = "First feature"
+            , fragmentPR = 99
+            }
+        ]
+      result = renderSection testConfig testVersion testDay frags
+      idx42 = T.breakOn "PR 42" result
+      idx99 = T.breakOn "PR 99" result
+  result `shouldContain` "PR 42"
+  result `shouldContain` "PR 99"
+  -- PR 99 should appear before PR 42 (shorter prefix means earlier position)
+  H.assert $ T.length (fst idx99) < T.length (fst idx42)
+
+-- | Fragments with only non-notable kinds are excluded from the rendered output.
+prop_non_notable_excluded :: Property
+prop_non_notable_excluded = H.propertyOnce $ do
+  let frags =
+        [ Fragment
+            { fragmentProject = "cardano-api"
+            , fragmentKinds = ["test"]
+            , fragmentDescription = "Add test for X"
+            , fragmentPR = 50
+            }
+        ]
+      result = renderSection testConfig testVersion testDay frags
+  result `shouldContain` "## 8.5.0.0"
+  result `shouldNotContain` "Add test for X"
+
+-- | A fragment with a mix of notable and non-notable kinds is included,
+-- and ALL kind labels appear in the parenthesized list.
+prop_mixed_notable :: Property
+prop_mixed_notable = H.propertyOnce $ do
+  let frags =
+        [ Fragment
+            { fragmentProject = "cardano-api"
+            , fragmentKinds = ["bugfix", "refactoring"]
+            , fragmentDescription = "Fix and refactor"
+            , fragmentPR = 42
+            }
+        ]
+      result = renderSection testConfig testVersion testDay frags
+  result `shouldContain` "Fix and refactor"
+  result `shouldContain` "bugfix"
+  result `shouldContain` "refactoring"
+
+-- | Multi-line descriptions are preserved in the rendered output.
+prop_multiline_description :: Property
+prop_multiline_description = H.propertyOnce $ do
+  let frags =
+        [ Fragment
+            { fragmentProject = "cardano-api"
+            , fragmentKinds = ["bugfix"]
+            , fragmentDescription = "Fix line one\nFix line two"
+            , fragmentPR = 42
+            }
+        ]
+      result = renderSection testConfig testVersion testDay frags
+  result `shouldContain` "Fix line one"
+  result `shouldContain` "Fix line two"
+
+-- | An empty fragment list still renders the version header.
+prop_empty_fragments :: Property
+prop_empty_fragments = H.propertyOnce $ do
+  let result = renderSection testConfig testVersion testDay []
+  result `shouldContain` "## 8.5.0.0"
+  result `shouldContain` "2026-03-25"
+
+-- | Fragments with kinds not present in the config are treated as non-notable
+-- and excluded from the rendered output.
+prop_unknown_kind_non_notable :: Property
+prop_unknown_kind_non_notable = H.propertyOnce $ do
+  let frags =
+        [ Fragment
+            { fragmentProject = "cardano-api"
+            , fragmentKinds = ["nonexistent-kind"]
+            , fragmentDescription = "This should be hidden"
+            , fragmentPR = 77
+            }
+        ]
+      result = renderSection testConfig testVersion testDay frags
+  result `shouldContain` "## 8.5.0.0"
+  result `shouldNotContain` "This should be hidden"
+  result `shouldNotContain` "PR 77"
+
+-- | Two fragments with the same PR number are both rendered.
+prop_duplicate_pr :: Property
+prop_duplicate_pr = H.propertyOnce $ do
+  let frags =
+        [ Fragment
+            { fragmentProject = "cardano-api"
+            , fragmentKinds = ["bugfix"]
+            , fragmentDescription = "First fix"
+            , fragmentPR = 42
+            }
+        , Fragment
+            { fragmentProject = "cardano-api"
+            , fragmentKinds = ["feature"]
+            , fragmentDescription = "Second entry same PR"
+            , fragmentPR = 42
+            }
+        ]
+      result = renderSection testConfig testVersion testDay frags
+  result `shouldContain` "First fix"
+  result `shouldContain` "Second entry same PR"

--- a/herald/test/Test/Herald/Terminal.hs
+++ b/herald/test/Test/Herald/Terminal.hs
@@ -1,0 +1,55 @@
+module Test.Herald.Terminal (tests) where
+
+import Data.Text qualified as T
+
+import Hedgehog (Property, (===))
+import Hedgehog.Extras qualified as H
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Hedgehog (testProperty)
+
+import Herald.Terminal (stripAnsi)
+
+tests :: TestTree
+tests =
+  testGroup
+    "Herald.Terminal"
+    [ testProperty "stripAnsi removes arrow key escape sequences" prop_strip_arrow_keys
+    , testProperty "stripAnsi removes colour codes" prop_strip_colour
+    , testProperty "stripAnsi preserves plain text" prop_strip_plain
+    , testProperty "stripAnsi handles mixed content" prop_strip_mixed
+    , testProperty "stripAnsi handles truncated escape sequence" prop_strip_truncated
+    ]
+
+-- | Arrow-key escapes (\ESC[A, \ESC[B, etc.) are stripped completely.
+prop_strip_arrow_keys :: Property
+prop_strip_arrow_keys = H.propertyOnce $ do
+  stripAnsi "hello\ESC[Aworld" === "helloworld"
+  stripAnsi "\ESC[B\ESC[Afoo" === "foo"
+  stripAnsi "start\ESC[C\ESC[Dend" === "startend"
+
+-- | SGR colour codes (\ESC[31m, \ESC[1;32m, etc.) are stripped.
+prop_strip_colour :: Property
+prop_strip_colour = H.propertyOnce $ do
+  stripAnsi "\ESC[31mred\ESC[0m" === "red"
+  stripAnsi "\ESC[1;32mbold green\ESC[0m" === "bold green"
+
+-- | Plain text without escape sequences passes through unchanged.
+prop_strip_plain :: Property
+prop_strip_plain = H.propertyOnce $ do
+  stripAnsi "No escape sequences here" === "No escape sequences here"
+  stripAnsi "" === T.empty
+
+-- | Mixed plain text and escape sequences: only the escapes are removed.
+prop_strip_mixed :: Property
+prop_strip_mixed = H.propertyOnce $ do
+  stripAnsi "Fix \ESC[Aserialization\ESC[B bug" === "Fix serialization bug"
+
+-- | Truncated escape sequences (no terminal letter) do not crash.
+prop_strip_truncated :: Property
+prop_strip_truncated = H.propertyOnce $ do
+  -- ESC[ with no following letter
+  stripAnsi "hello\ESC[" === "hello"
+  -- ESC[ with params but no terminal letter
+  stripAnsi "hello\ESC[31" === "hello"
+  -- Just ESC with no bracket
+  stripAnsi "hello\ESC" === "hello\ESC"


### PR DESCRIPTION
This PR adds `herald` - a release aid tool. Goals of herald:
- automate changelog building, version bumping
- integration with github actions

## What changes?
- `herald` operates on changelogs in checked-in files in `.changes/`, instead of github PR description. The advantage is that this file can be reviewed in the same way as the code. 

- `herald` provides `herald new` interactive command for creating changelog file. If you don't like `herald` - no problem - just copy `.changes/_TEMPLATE.yml` and put your changelog fragment there. Comments there will guide you.

- `herald` is shipped with two reusable github actions:
  - `validate` - checks if the new changelog fragment is correct, the PR number matches of the PR that introduces it and the projects are selected accordingly to the diff.
  - `release` - collects changelog fragments, combines them, selects automatic version bump and creates a release PR

- `herald` is configured by `.herald.yml` configuration file at the top level of the repository.


## See it in action

Have a look at "Check changelog fragments" workflows in the following PRs:
1. Change with a changelog https://github.com/carbolymer/cardano-api/pull/3
2. Change without a changelog (negative case) https://github.com/carbolymer/cardano-api/pull/2

There's also a release PR produced by release action: https://github.com/carbolymer/cardano-api/pull/4

See sample migration to `herald`: https://github.com/IntersectMBO/cardano-api/pull/1164

## How to review

I'd suggest starting from `README.md`. `REQIREMENTS.md` specifies requirements for the tool as well as comparison with existing changelog generation tools.

I encourage reviewers to run the tool and try it.

Reviewing tests can also give some insight.

Reviewing codebase may not be that effective, as this is 100% generated from Claude and I focused on the tool behaviours and output rather than producing top quality code.


[![Hydra](https://img.shields.io/badge/ci-hydra-blue)](https://ci.iog.io/jobset/input-output-hk-cardano-dev/pullrequest-22)