### PR TITLE
drop support for x86_64-darwin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -135,7 +135,7 @@
             aarch64-linux =
               heraldProject.projectCross.aarch64-multiplatform-musl.hsPkgs.herald.components.exes.herald;
           }
-          // lib.optionalAttrs (system == "x86_64-darwin" || system == "aarch64-darwin") {
+          // lib.optionalAttrs (system == "aarch64-darwin") {
             ${system} = heraldExe;
           };
         checks =


### PR DESCRIPTION
- Nixpkgs expects to drop support for intel macs in 26.11 as per Nixpkgs 25.11 [release notes](https://nixos.org/manual/nixpkgs/stable/release-notes#sec-nixpkgs-release-25.11-highlights).                          
- It was [decided](https://input-output-rnd.slack.com/archives/CG1FBSDMM/p1776704401411139?thread_ts=1776677872.325309&cid=CG1FBSDMM) to no longer build x86_64-darwin on [ci.iog.io](https://ci.iog.io) to reduce strain on the struggling mac builders.