### PR TITLE
Update herald workflow templates

### DIFF
--- a/herald/.github/workflows/release.yml
+++ b/herald/.github/workflows/release.yml
@@ -25,28 +25,32 @@ on:
         description: Explicit version (A.B.C.D). Leave empty to auto-compute.
         required: false
         type: string
-
-permissions:
-  contents: write
-  pull-requests: write
+      branch:
+        description: Branch to release from and target for the PR. Leave empty to use the branch selected above.
+        required: false
+        type: string
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.branch || github.ref_name }}
           fetch-depth: 0
 
       - uses: cachix/install-nix-action@v30
         with:
           extra_nix_config: |
-            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
-            substituters = https://cache.iog.io/ https://cache.nixos.org/
+            accept-flake-config = true
 
       - uses: input-output-hk/cardano-dev/herald/.github/actions/release@main
         with:
           package: ${{ inputs.package }}
           version: ${{ inputs.version }}
+          base-branch: ${{ inputs.branch || github.ref_name }}
           # herald-ref: github:input-output-hk/cardano-dev  # default
           # config: .herald.yml                               # default

--- a/herald/.github/workflows/validate-changelogs.yml
+++ b/herald/.github/workflows/validate-changelogs.yml
@@ -5,13 +5,22 @@
 #   - Modified projects have at least one changelog fragment (--diff)
 #   - PR numbers inside fragments match the pull request number (--pr)
 
-name: Validate Changelogs
+name: Check changelog fragments
+
+permissions:
+  contents: read
 
 on:
+  merge_group:
   pull_request:
+    types: [opened, synchronize, ready_for_review]
 
 jobs:
   validate:
+    # Skip for merge_group: batched diffs would cause false positives and
+    # PR number context is unavailable.  The trigger is kept so the check
+    # reports "skipped" (passes) when this is a required status check.
+    if: ${{ github.event_name != 'merge_group' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -23,8 +32,7 @@ jobs:
       - uses: cachix/install-nix-action@v30
         with:
           extra_nix_config: |
-            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
-            substituters = https://cache.iog.io/ https://cache.nixos.org/
+            accept-flake-config = true
 
       - uses: input-output-hk/cardano-dev/herald/.github/actions/validate@main
         # with:


### PR DESCRIPTION
## Summary

Bring the herald example workflow templates in line with improvements already deployed in cardano-api.

### release.yml
- Add optional `branch` input so releases can target a branch other than the one selected in the UI
- Pass `base-branch` to the release action
- Check out the chosen branch explicitly via `ref:`
- Move `permissions` from workflow level to job level (least-privilege)
- Replace explicit `trusted-public-keys`/`substituters` with `accept-flake-config = true`

### validate-changelogs.yml
- Rename workflow to "Check changelog fragments"
- Add `merge_group` trigger so the check reports "skipped" (passes) when used as a required status check with merge queue - without it the merge queue stalls waiting for a status that never arrives
- Restrict `pull_request` trigger to `opened`, `synchronize`, `ready_for_review`
- Skip validation on `merge_group` events (batched diffs cause false positives, PR number context is unavailable)
- Add explicit `permissions: contents: read`
- Replace explicit `trusted-public-keys`/`substituters` with `accept-flake-config = true`