### PR TITLE
Improve hydra caching for herald binary.

### DIFF
--- a/.changes/20260519_herald_binary_diet.yml
+++ b/.changes/20260519_herald_binary_diet.yml
@@ -1,0 +1,6 @@
+project: herald
+pr: 31
+kind:
+  - maintenance
+description: |
+  Optimise herald binary: add -O2, -split-sections, -flate-specialise, -optl-s, RTS tuning (-A64m -I0), strip nix store references via removeReferencesTo, and add heraldStripped to hydraJobs for cache substitution. Reduces CI nix closure from 382 MiB / 234 paths to 30 MiB / 3 paths.

--- a/.changes/20260519_herald_release_outputs.yml
+++ b/.changes/20260519_herald_release_outputs.yml
@@ -1,0 +1,6 @@
+project: herald-release
+pr: 31
+kind:
+  - feature
+description: |
+  Add action outputs (pr-url, pr-number, version, tag) and GHA annotation for release summary.

--- a/.changes/20260519_herald_validate_error_annotations.yml
+++ b/.changes/20260519_herald_validate_error_annotations.yml
@@ -1,0 +1,6 @@
+project: herald-validate
+pr: 31
+kind:
+  - feature
+description: |
+  Surface validation errors as GitHub error annotations and step summary instead of burying them in the log.

--- a/actions/herald-release/action.yml
+++ b/actions/herald-release/action.yml
@@ -29,6 +29,20 @@ inputs:
     required: false
     default: ''
 
+outputs:
+  pr-url:
+    description: URL of the release pull request.
+    value: ${{ steps.pr.outputs.url }}
+  pr-number:
+    description: Number of the release pull request.
+    value: ${{ steps.pr.outputs.number }}
+  version:
+    description: The released version (computed or explicit).
+    value: ${{ steps.version.outputs.value }}
+  tag:
+    description: The git tag created for the release.
+    value: ${{ steps.version.outputs.value && format('{0}-{1}', inputs.package, steps.version.outputs.value) }}
+
 runs:
   using: composite
   steps:
@@ -210,4 +224,4 @@ runs:
         sed -i 's/^        //' /tmp/pr-body.md
         gh pr edit "$PR_NUMBER" --body-file /tmp/pr-body.md
 
-        echo "::notice::Release PR: ${{ steps.pr.outputs.url }}"
+        echo "::notice::Release $PACKAGE $VERSION - PR: ${{ steps.pr.outputs.url }}"

--- a/actions/herald-validate/action.yml
+++ b/actions/herald-validate/action.yml
@@ -72,4 +72,23 @@ runs:
         echo "::group::Fetching herald"
         HERALD="$(nix build --accept-flake-config "${{ inputs.herald-ref }}#herald" --no-link --print-out-paths)/bin/herald"
         echo "::endgroup::"
-        "$HERALD" $ARGS validate $VALIDATE_ARGS
+        if ! OUTPUT=$("$HERALD" $ARGS validate $VALIDATE_ARGS 2>&1); then
+          current=""
+          while IFS= read -r line; do
+            if [[ "$line" =~ ^[^[:space:]] ]]; then
+              [ -n "$current" ] && echo "::error::$current"
+              current="$line"
+            else
+              current="$current $line"
+            fi
+          done <<< "$OUTPUT"
+          [ -n "$current" ] && echo "::error::$current"
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+        ### Changelog validation failed
+
+        \`\`\`
+        $OUTPUT
+        \`\`\`
+        EOF
+          exit 1
+        fi

--- a/flake.nix
+++ b/flake.nix
@@ -114,6 +114,19 @@
           else
             heraldExe;
 
+        # Strip nix store references from the static binary so consumers
+        # only download the single output, not the full build closure.
+        heraldStripped =
+          if pkgs.stdenv.hostPlatform.isLinux then
+            pkgs.runCommand "herald" { nativeBuildInputs = [ pkgs.removeReferencesTo ]; } ''
+              mkdir -p $out/bin
+              cp ${heraldPlatformExe}/bin/herald $out/bin/herald
+              chmod +w $out/bin/herald
+              remove-references-to -t ${heraldPlatformExe} $out/bin/herald
+            ''
+          else
+            heraldPlatformExe;
+
         ghcVersion = "ghc9122";
 
         # Pinned tool versions shared between devShell and CI lint check
@@ -200,7 +213,7 @@
         apps = pkgs.lib.foldl' (acc: s: acc // { ${s} = mkScriptApp s; }) {
           herald = {
             type = "app";
-            program = "${heraldPlatformExe}/bin/herald";
+            program = "${heraldStripped}/bin/herald";
           };
           herald-dy = {
             type = "app";
@@ -208,7 +221,7 @@
           };
         } scripts;
         packages = {
-          herald = heraldPlatformExe;
+          herald = heraldStripped;
         }
         // heraldRelease;
         devShells = {
@@ -230,7 +243,7 @@
             herald = {
               inherit (heraldProject.hsPkgs.herald.components) library;
               exe = heraldExe;
-              static = heraldPlatformExe;
+              static = heraldStripped;
               tests = heraldTestExe;
               e2e = heraldE2eExe;
             }

--- a/herald/cabal.project
+++ b/herald/cabal.project
@@ -1,5 +1,8 @@
 packages: .
 
+-- Allow GHC to parallelise within a single package via -jsem
+semaphore: true
+
 constraints:
   -- haskell.nix patch does not work for 1.6.8
   any.crypton-x509-system < 1.6.8

--- a/herald/herald.cabal
+++ b/herald/herald.cabal
@@ -7,12 +7,19 @@ author: Input Output Global
 maintainer: operations@iohk.io
 build-type: Simple
 
+-- -flate-specialise: defer specialisation of overloaded functions to use sites
+-- -split-sections: enable linker to discard unused code sections
+-- -optl-s: strip symbols at link time
 common warnings
   ghc-options:
     -Wall
     -Wredundant-constraints
     -Wincomplete-record-updates
     -Wincomplete-uni-patterns
+    -O2
+    -flate-specialise
+    -split-sections
+    -optl-s
 
 common lang
   default-language: GHC2021
@@ -69,10 +76,15 @@ library
     transformers,
     yaml,
 
+-- RTS tuning: large nursery so GC never triggers in a short-lived CLI run,
+-- disable idle GC
 executable herald
   import: warnings, lang
   hs-source-dirs: app
   main-is: Main.hs
+  ghc-options:
+    "-with-rtsopts=-A64m -I0"
+
   autogen-modules:
     PackageInfo_herald
     Paths_herald


### PR DESCRIPTION
## Summary

- Strip nix store references from static herald binary via `removeReferencesTo`, reducing nix closure size
- Add `heraldStripped` to `hydraJobs` so Hydra caches the stripped output on `cache.iog.io`
- Add binary optimisation flags: `-O2`, `-flate-specialise`, `-split-sections`, `-optl-s`
- Tune RTS for short-lived CLI: `-A64m -I0` (large nursery, no idle GC)
- Enable cabal semaphores for parallel builds
- Add outputs to `herald-release` action (`pr-url`, `pr-number`, `version`, `tag`)
- Add GHA annotation for release summary

## Static binary comparison

| | `main` | this PR | change |
|---|---|---|---|
| binary size | 30 MiB | 21 MiB | -30% |
| stripped | no | yes | |
| closure size | 38.3 MiB / 3 paths | 29.9 MiB / 3 paths | -22% |
| startup (avg) | 1,595 µs | 1,041 µs | -35% |