### PR TITLE
Pin herald to 0.1.1.0

### DIFF
--- a/.changes/20260519_herald_release_pin_version.yml
+++ b/.changes/20260519_herald_release_pin_version.yml
@@ -1,0 +1,6 @@
+project: herald-release
+pr: 34
+kind:
+  - maintenance
+description: |
+  Pin default herald-ref to github:input-output-hk/cardano-dev/herald-0.1.1.0 for reproducible builds.

--- a/.changes/20260519_herald_validate_pin_version.yml
+++ b/.changes/20260519_herald_validate_pin_version.yml
@@ -1,0 +1,6 @@
+project: herald-validate
+pr: 34
+kind:
+  - maintenance
+description: |
+  Pin default herald-ref to github:input-output-hk/cardano-dev/herald-0.1.1.0 for reproducible builds.

--- a/actions/herald-release/action.yml
+++ b/actions/herald-release/action.yml
@@ -21,7 +21,7 @@ inputs:
   herald-ref:
     description: Flake reference for the cardano-dev repository containing herald.
     required: false
-    default: github:input-output-hk/cardano-dev
+    default: github:input-output-hk/cardano-dev/herald-0.1.1.0
   base-branch:
     description: >
       Branch to target for the release PR. If omitted, auto-detected from the

--- a/actions/herald-validate/action.yml
+++ b/actions/herald-validate/action.yml
@@ -8,7 +8,7 @@ inputs:
   herald-ref:
     description: Flake reference for the cardano-dev repository containing herald.
     required: false
-    default: github:input-output-hk/cardano-dev
+    default: github:input-output-hk/cardano-dev/herald-0.1.1.0
   config:
     description: Path to the herald config file, relative to the repository root.
     required: false


### PR DESCRIPTION
## Summary

- Pin default `herald-ref` to `github:input-output-hk/cardano-dev/herald-0.1.1.0` in both `herald-validate` and `herald-release` actions for reproducible builds
