### PR TITLE
Improve herald-release action: actor, CHaP instructions, resilience

### DIFF
--- a/.changes/20260526_herald_docs_chap_release_flow.yml
+++ b/.changes/20260526_herald_docs_chap_release_flow.yml
@@ -1,0 +1,6 @@
+project: herald
+pr: 40
+kind:
+  - documentation
+description: |
+  Update README, spec requirements, ADR, and batch stories to reflect deferred tagging, release PR resilience improvements, CHaP submission instructions, and trigger author visibility.

--- a/.changes/20260526_herald_release_chap_instructions.yml
+++ b/.changes/20260526_herald_release_chap_instructions.yml
@@ -1,0 +1,6 @@
+project: herald-release
+pr: 40
+kind:
+  - feature
+description: |
+  Optionally include CHaP PR submission instructions in the release PR body. When chap-instructions is enabled and the project has a cabal-file, the PR body shows copy-paste commands for creating the CHaP PR after signing.

--- a/.changes/20260526_herald_release_resilience.yml
+++ b/.changes/20260526_herald_release_resilience.yml
@@ -1,0 +1,6 @@
+project: herald-release
+pr: 40
+kind:
+  - bugfix
+description: |
+  Improve release action resilience: skip tag creation (deferred to signing), make release fragment idempotent on re-runs, add set -euo pipefail to PR body generation, and use explicit push targets.

--- a/.changes/20260526_herald_release_show_actor.yml
+++ b/.changes/20260526_herald_release_show_actor.yml
@@ -1,0 +1,6 @@
+project: herald-release
+pr: 40
+kind:
+  - feature
+description: |
+  Show who triggered the release in the PR body. The action reads GITHUB_ACTOR from the runner environment and adds "Triggered by @USERNAME" at the top of the PR description.

--- a/.github/workflows/herald-release.yml
+++ b/.github/workflows/herald-release.yml
@@ -5,10 +5,10 @@
 # What it does:
 #   1. Batches changelog fragments into a new changelog section
 #   2. Bumps the version (cabal file or version.txt, auto-computed or explicit)
-#   3. Creates a release commit and PACKAGE-VERSION tag
+#   3. Creates a release commit (tag is deferred to the manual signing step)
 #   4. Adds a release changelog fragment for the next cycle
 #   5. Pushes to a release/PACKAGE-VERSION branch
-#   6. Opens a PR with instructions for signing the commits
+#   6. Opens a PR with signing instructions (and optionally CHaP submission commands)
 
 name: Release
 

--- a/actions/herald-release/action.yml
+++ b/actions/herald-release/action.yml
@@ -1,8 +1,8 @@
 name: Herald Release
 description: >
-  Batch changelog fragments for a package, create a release commit and tag,
+  Batch changelog fragments for a package, create a release commit,
   open a pull request on a release branch, and add a release changelog fragment
-  for the next cycle.
+  for the next cycle. The tag is created manually during signing.
 
 inputs:
   package:
@@ -28,6 +28,12 @@ inputs:
       repository's default branch.
     required: false
     default: ''
+  chap-instructions:
+    description: >
+      Include CHaP PR instructions in the release PR body.
+      Only applies to projects with a cabal-file in the herald config.
+    required: false
+    default: 'false'
 
 outputs:
   pr-url:
@@ -40,7 +46,7 @@ outputs:
     description: The released version (computed or explicit).
     value: ${{ steps.version.outputs.value }}
   tag:
-    description: The git tag created for the release.
+    description: The git tag name for the release (created during signing, not by this action).
     value: ${{ steps.version.outputs.value && format('{0}-{1}', inputs.package, steps.version.outputs.value) }}
 
 runs:
@@ -102,19 +108,6 @@ runs:
           echo "value=$VERSION" >> "$GITHUB_OUTPUT"
         fi
 
-    - name: Check tag does not exist
-      shell: bash
-      run: |
-        TAG="${{ inputs.package }}-${{ steps.version.outputs.value }}"
-        if git rev-parse "$TAG" >/dev/null 2>&1; then
-          echo "::error::Tag $TAG already exists locally. Delete it before re-running."
-          exit 1
-        fi
-        if git ls-remote --tags origin "refs/tags/$TAG" | grep -q .; then
-          echo "::error::Tag $TAG already exists on remote. Delete it before re-running."
-          exit 1
-        fi
-
     - name: Create release branch
       shell: bash
       run: |
@@ -133,13 +126,12 @@ runs:
           VERSION_ARG="--version ${{ inputs.version }}"
         fi
 
-        $HERALD $CONFIG batch "${{ inputs.package }}" --commit-tag $VERSION_ARG
+        $HERALD $CONFIG batch "${{ inputs.package }}" --commit $VERSION_ARG
 
-    - name: Push release branch and tag
+    - name: Push release branch
       shell: bash
       run: |
         git push -q --force -u origin "$RELEASE_BRANCH"
-        git push -q origin "$RELEASE_TAG"
 
     - name: Create or reuse pull request
       id: pr
@@ -182,33 +174,58 @@ runs:
         VERSION="${{ steps.version.outputs.value }}"
         PR_NUMBER="${{ steps.pr.outputs.number }}"
 
-        $HERALD $CONFIG new \
-          --project "$PACKAGE" \
-          --kind release \
-          --description "Release $PACKAGE $VERSION" \
-          --pr "$PR_NUMBER"
+        if grep -rlq "kind:" .changes/ 2>/dev/null \
+            | xargs -r grep -l "release" \
+            | xargs -r grep -l "project: $PACKAGE" \
+            | xargs -r grep -lq "Release $PACKAGE $VERSION"; then
+          echo "::notice::Release fragment for $PACKAGE $VERSION already exists, skipping"
+        else
+          $HERALD $CONFIG new \
+            --project "$PACKAGE" \
+            --kind release \
+            --description "Release $PACKAGE $VERSION" \
+            --pr "$PR_NUMBER"
+        fi
 
         git add .changes/
-        git commit --no-verify --no-gpg-sign \
-          -m "Add release changelog fragment for $PACKAGE $VERSION"
-        git push --force
+        git diff --cached --quiet || \
+          git commit --no-verify --no-gpg-sign \
+            -m "Add release changelog fragment for $PACKAGE $VERSION"
+        git push --force origin "$RELEASE_BRANCH"
 
     - name: Update PR body
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
+        set -euo pipefail
         PACKAGE="${{ inputs.package }}"
         VERSION="${{ steps.version.outputs.value }}"
         DEFAULT_BRANCH="${{ steps.default-branch.outputs.name }}"
         TAG="$RELEASE_TAG"
         BRANCH="$RELEASE_BRANCH"
         PR_NUMBER="${{ steps.pr.outputs.number }}"
+        ACTOR="${GITHUB_ACTOR:-}"
+        REPO_URL="https://github.com/${{ github.repository }}"
         COMMIT_COUNT=$(git rev-list --count "origin/${DEFAULT_BRANCH}..HEAD")
-        # The tag is on the batch commit, which is one before the release fragment
-        TAG_OFFSET=$((COMMIT_COUNT - 1))
+        CONFIG="${{ inputs.config }}"
+        CABAL_FILE=$(yq -r ".projects.\"${PACKAGE}\".\"cabal-file\" // \"\"" "$CONFIG")
 
-        cat > /tmp/pr-body.md <<EOF
+        SUBDIR_ARG=""
+        if [ -n "$CABAL_FILE" ]; then
+          SUBDIR=$(dirname "$CABAL_FILE")
+          if [ "$SUBDIR" != "." ]; then
+            SUBDIR_ARG=" $SUBDIR"
+          fi
+        fi
+
+        if [ -n "$ACTOR" ]; then
+          printf 'Triggered by @%s\n\n' "$ACTOR" > /tmp/pr-body.md
+        else
+          : > /tmp/pr-body.md
+        fi
+
+        cat >> /tmp/pr-body.md <<EOF
         ## Summary
 
         - Batch changelog fragments for \`$PACKAGE\` into version \`$VERSION\`
@@ -216,20 +233,52 @@ runs:
         - Bump \`.cabal\` version to \`$VERSION\`
         - Remove consumed changelog fragments
         - Add release changelog fragment for the next cycle
-        - Tag: \`$TAG\`
 
         ## Before merging
 
-        The commits in this PR are **unsigned**. To sign them before merging, run:
+        ### Step 1: Sign the release
+
+        The commits in this PR are **unsigned** and the tag has not been created yet. Run on a clean working tree:
 
         \`\`\`bash
         git fetch origin $BRANCH
-        git checkout $BRANCH
+        git checkout -B $BRANCH origin/$BRANCH
         git rebase HEAD~${COMMIT_COUNT} --exec 'git commit --amend --no-edit -S'
-        git tag -f $TAG HEAD~${TAG_OFFSET}
+        git tag -s $TAG HEAD~$((COMMIT_COUNT - 1))  # batch commit, one before HEAD
         git push --force origin $BRANCH
-        git push --force origin $TAG
+        git push origin $TAG
         \`\`\`
+        EOF
+
+        if [ "${{ inputs.chap-instructions }}" = "true" ] && [ -n "$CABAL_FILE" ]; then
+          cat >> /tmp/pr-body.md <<'CHAP'
+
+        ### Step 2: Submit to CHaP
+
+        Requires: signed tag pushed to remote (step 1 complete), [gh](https://cli.github.com/) installed and authenticated.
+
+        Run in your [cardano-haskell-packages](https://github.com/intersectmbo/cardano-haskell-packages) checkout:
+
+        ```bash
+        set -euo pipefail
+        git fetch origin
+        git checkout -b __TAG__ origin/main
+        TAG_SHA=$(git ls-remote __REPO__ refs/tags/__TAG__ | cut -f1)
+        ./scripts/add-from-github.sh __REPO__ "$TAG_SHA"__SUBDIR__
+        git push -u origin __TAG__
+        CHAP_PR=$(gh pr create --repo intersectmbo/cardano-haskell-packages \
+          --head __TAG__ \
+          --title "Add __TAG__" \
+          --body "From __REPO__ tag __TAG__")
+        echo ">> CHaP PR: $CHAP_PR"
+        gh pr comment __PR_NUMBER__ --repo __GH_REPO__ \
+          --body "- $CHAP_PR"
+        ```
+        CHAP
+          sed -i "s|__TAG__|$TAG|g; s|__REPO__|$REPO_URL|g; s|__SUBDIR__|$SUBDIR_ARG|g; s|__PR_NUMBER__|$PR_NUMBER|g; s|__GH_REPO__|${{ github.repository }}|g" /tmp/pr-body.md
+        fi
+
+        cat >> /tmp/pr-body.md <<EOF
 
         Generated with [herald](https://github.com/input-output-hk/cardano-dev)
         EOF

--- a/actions/herald-release/example.yml
+++ b/actions/herald-release/example.yml
@@ -6,11 +6,11 @@
 #
 # What it does:
 #   1. Batches changelog fragments into a new changelog section
-#   2. Bumps the .cabal version (auto-computed or explicit)
-#   3. Creates a release commit and PACKAGE-VERSION tag
+#   2. Bumps the version (cabal file or version.txt, auto-computed or explicit)
+#   3. Creates a release commit (tag is deferred to the manual signing step)
 #   4. Adds a release changelog fragment for the next cycle
 #   5. Pushes to a release/PACKAGE-VERSION branch
-#   6. Opens a PR with instructions for signing the commits
+#   6. Opens a PR with signing instructions (and optionally CHaP submission commands)
 
 name: Release
 

--- a/herald/README.md
+++ b/herald/README.md
@@ -313,23 +313,26 @@ jobs:
 The release action:
 1. Computes the next version (auto or explicit)
 2. Creates a `release/PACKAGE-VERSION` branch
-3. Batches changelog fragments, commits, and tags (`--commit-tag`)
-4. Pushes the branch and tag
-5. Opens a PR with the changes
-6. Creates a release changelog fragment for the next cycle
-7. Updates the PR body with signing instructions
+3. Batches changelog fragments and commits (`--commit`)
+4. Pushes the branch
+5. Opens a PR (shows trigger author, signing instructions, optionally CHaP submission commands)
+6. Creates a release changelog fragment for the next cycle (idempotent on re-runs)
 
-Since the commits are unsigned (created by `github-actions[bot]`), the PR body
-includes exact git commands for the maintainer to sign the commits before merging:
+Since the commits are unsigned (created by `github-actions[bot]`) and the tag has
+not been created yet, the PR body includes exact git commands for the maintainer
+to sign the commits and create the signed tag before merging:
 
 ```bash
 git fetch origin release/cardano-api-9.0.0.0
-git checkout release/cardano-api-9.0.0.0
+git checkout -B release/cardano-api-9.0.0.0 origin/release/cardano-api-9.0.0.0
 git rebase HEAD~2 --exec 'git commit --amend --no-edit -S'
-git tag -f cardano-api-9.0.0.0 HEAD~1
-git push --force-with-lease origin release/cardano-api-9.0.0.0
-git push --force origin cardano-api-9.0.0.0
+git tag -s cardano-api-9.0.0.0 HEAD~1
+git push --force origin release/cardano-api-9.0.0.0
+git push origin cardano-api-9.0.0.0
 ```
+
+For projects with a `cabal-file` in `.herald.yml`, the PR body can also include
+copy-paste commands for creating a CHaP PR (enabled via the `chap-instructions` input).
 
 ## CLI reference
 

--- a/herald/spec/decisions/001-build-vs-buy.md
+++ b/herald/spec/decisions/001-build-vs-buy.md
@@ -87,6 +87,7 @@ Every approach requires a custom PVP version-bumping script - no tool provides t
 
 A fully custom tool (Herald) was built.
 It handles all requirements natively: PVP 4-part versioning with auto-bumping, multi-select kinds, mono-repo projects, non-notable filtering, fragment validation, and automated release PR creation.
-Tagging is incorporated via `herald batch --commit-tag`, replacing the need for a separate `tag.sh` script.
+Tagging is available via `herald batch --commit-tag`, replacing the need for a separate `tag.sh` script.
+The release action uses `--commit` only; tagging is deferred to the manual signing step.
 
 Herald is implemented in Haskell, built with nix (GHC 9.12.2), and distributed as a flake app at `github:input-output-hk/cardano-dev#herald`.

--- a/herald/spec/requirements.md
+++ b/herald/spec/requirements.md
@@ -90,11 +90,11 @@ A `workflow_dispatch` action takes a package name and an optional PVP version st
 2. Collects unreleased fragments for that package.
 3. Generates the version's changelog section.
 4. Updates the version source (`.cabal` file or version file).
-5. Creates a release commit and `PACKAGE-VERSION` tag.
+5. Creates a release commit (tag is deferred to the manual signing step).
 6. Pushes to a `release/PACKAGE-VERSION` branch.
 7. Opens a PR with the changes.
-8. Creates a release changelog fragment for the next cycle.
-9. Updates the PR body with commit signing instructions.
+8. Creates a release changelog fragment for the next cycle (idempotent on re-runs).
+9. Updates the PR body with the trigger author, commit signing instructions, and optionally CHaP submission commands.
 
 Provided as reusable composite GitHub Actions (`herald-validate` and `herald-release`).
 
@@ -130,6 +130,20 @@ Herald reads, bumps, and writes the version file identically to a `.cabal` versi
 
 Stories: [version-sources](stories/version-sources.md), [config](stories/config.md).
 Decisions: [ADR 002](decisions/002-version-file.md).
+
+## R12: Release PR shows trigger author
+
+The release PR body identifies the GitHub user who triggered the workflow.
+This improves auditability and makes it clear who to contact about signing.
+The `herald-release` composite action reads `GITHUB_ACTOR` from the runner environment and includes "Triggered by @USERNAME" in the PR body.
+
+## R13: CHaP submission instructions in release PR
+
+The release PR body includes copy-paste commands for creating a CHaP PR after signing.
+Only shown for projects with a `cabal-file` in `.herald.yml`; version-file-only projects omit the section.
+The commands resolve the tag SHA at execution time, so they work correctly after the signing rebase.
+
+Stories: [batch](stories/batch.md).
 
 ---
 

--- a/herald/spec/stories/batch.md
+++ b/herald/spec/stories/batch.md
@@ -107,3 +107,9 @@ A successful batch returns:
 ### Result fields
 31. `BatchResult` contains correct package name, version, changelog path, and version source path.
 32. Version-file `BatchResult` has correct fields.
+
+### CHaP submission instructions (release PR body)
+33. When `chap-instructions` is enabled and the project has a `cabal-file`, the release PR body includes a "Step 2: Submit to CHaP" section with copy-paste commands (branch creation, `add-from-github.sh` with repo URL and subdir, push, `gh pr create`, `gh pr comment`).
+34. When the project uses `version-file` only, the CHaP section is omitted.
+35. When the `cabal-file` path contains a directory component (e.g. `sub/pkg.cabal`), the `add-from-github.sh` invocation includes the subdir argument.
+36. When the `cabal-file` is at the repository root, no subdir argument is passed.


### PR DESCRIPTION
## Summary

- Show who triggered the release in the PR body (reads `GITHUB_ACTOR`)
- Optionally include CHaP PR submission instructions (`chap-instructions` input)
- Skip tag creation - deferred to the manual signing step
- Make release changelog fragment idempotent on re-runs
- Add `set -euo pipefail` to PR body generation step
- Use explicit push targets throughout

## Test plan

- [ ] Trigger a release for a cabal-file project with `chap-instructions: true`; verify CHaP commands appear with correct repo URL and subdir
- [ ] Trigger a release for a version-file project; verify CHaP section is omitted
- [ ] Re-run the same release; verify no duplicate release fragments are created
- [ ] Verify "Triggered by @username" appears at the top of the PR body
- [ ] Verify signing instructions use `git tag -s` (create signed) not `git tag -f` (force)